### PR TITLE
MCP Policy templates

### DIFF
--- a/docs/api/extensions/mcp.md
+++ b/docs/api/extensions/mcp.md
@@ -138,43 +138,42 @@ export PYTHONLOGLEVEL=INFO
 
 ## Policy Management CLI
 
-The extension includes a CLI tool for managing MCP authorization policies:
+Use the `eunomia-mcp` CLI in your terminal to manage your MCP authorization policies:
 
-### Initialize Project
-
-Create a new policy configuration:
+#### Initialize a New Project
 
 ```bash
-# Create default policy file
+# Create a default policy configuration file
 eunomia-mcp init
 
-# Create with custom name
+# Create policy configuration file with custom name
 eunomia-mcp init --policy-file my_policies.json
 
-# Generate policy + sample MCP server
+# Generate both policy configuration file and a sample MCP server
 eunomia-mcp init --sample
 ```
 
-### Validate Policies
+You can edit the created `mcp_policies.json` policy configuration file to your liking. Refer to the [templates][policy-templates] for example policies and rules.
 
-Verify your policy configuration:
+### Validate Policy Configuration
 
 ```bash
-# Validate policy syntax
+# Validate your policy file
 eunomia-mcp validate mcp_policies.json
 ```
 
-### Deploy Policies
-
-Push policies to your Eunomia server:
+### Push Policies to Eunomia
 
 ```bash
-# Push policies to server
+# Push your policy to Eunomia server
 eunomia-mcp push mcp_policies.json
 
-# Overwrite existing policies
+# Push your policy and overwrite existing ones
 eunomia-mcp push mcp_policies.json --overwrite
 ```
+
+!!! info
+    You need the Eunomia server running for the push operation.
 
 ### Development Workflow
 
@@ -198,15 +197,15 @@ eunomia-mcp push mcp_policies.json --overwrite
 | `resources/read` | `mcp:resources:{name}` | `read` | Blocks/forwards the request to the server |
 | `prompts/get`    | `mcp:prompts:{name}`   | `get`  | Blocks/forwards the request to the server |
 
-The middleware extracts contextual attributes from the request and passes them to the decision engine; these attributes can therefore be referenced inside policies to define dynamic rules.
+The middleware extracts contextual attributes from the MCP request and passes them to the decision engine; these attributes can therefore be referenced inside policies to define dynamic rules.
 
-| Attribute        | Type              | Description                                                          |
-| ---------------- | ----------------- | -------------------------------------------------------------------- |
-| `method`         | `str`             | The MCP method being called                                          |
-| `component_type` | `str`             | The type of component being called (`tools`, `prompts`, `resources`) |
-| `name`           | `str`             | The name of the component being called (e.g. `file_read`)            |
-| `uri`            | `str`             | The URI of the component being called (e.g. `mcp:tools:file_read`)   |
-| `arguments`      | `dict` (optional) | The arguments passed to the component being called                   |
+| Attribute        | Type              | Description                                              | Sample value           |
+| ---------------- | ----------------- | -------------------------------------------------------- | ---------------------- |
+| `method`         | `str`             | The MCP method                                           | `tools/list`           |
+| `component_type` | `str`             | The type of component: `tools`, `resources` or `prompts` | `tools`                |
+| `name`           | `str`             | The name of the component                                | `file_read`            |
+| `uri`            | `str`             | The MCP URI of the component                             | `mcp:tools:file_read`  |
+| `arguments`      | `dict` (Optional) | The arguments of the execution operation                 | `{"path": "file.txt"}` |
 
 ### Agent Authentication
 
@@ -360,3 +359,4 @@ logging.getLogger("eunomia_sdk").setLevel(logging.DEBUG)
 
 [mcp-docs]: https://modelcontextprotocol.io
 [fastmcp-docs]: https://gofastmcp.com/
+[policy-templates]: https://github.com/whataboutyou-ai/eunomia/tree/main/pkgs/extensions/mcp/templates

--- a/examples/mcp_planetary_weather/mcp_policies.json
+++ b/examples/mcp_planetary_weather/mcp_policies.json
@@ -5,6 +5,7 @@
   "rules": [
     {
       "name": "list-and-call",
+      "description": "All principals can list and call the specified tools",
       "effect": "allow",
       "principal_conditions": [],
       "resource_conditions": [
@@ -18,6 +19,7 @@
     },
     {
       "name": "list-only",
+      "description": "All principals can list the specified tool",
       "effect": "allow",
       "principal_conditions": [],
       "resource_conditions": [
@@ -31,6 +33,7 @@
     },
     {
       "name": "restricted-call",
+      "description": "All principals can call the specified tool with restricted arguments",
       "effect": "allow",
       "principal_conditions": [],
       "resource_conditions": [

--- a/pkgs/extensions/mcp/README.md
+++ b/pkgs/extensions/mcp/README.md
@@ -125,7 +125,7 @@ app = mcp.http_app(middleware=middleware)
 
 ### Policy Configuration
 
-Use the `eunomia-mcp` CLI to manage your MCP authorization policies:
+Use the `eunomia-mcp` CLI in your terminal to manage your MCP authorization policies:
 
 #### Initialize a New Project
 
@@ -140,7 +140,7 @@ eunomia-mcp init --policy-file my_policies.json
 eunomia-mcp init --sample
 ```
 
-You can now edit the policy configuration file to your liking.
+You can edit the created `mcp_policies.json` policy configuration file to your liking. Refer to the [templates][policy-templates] for example policies and rules.
 
 #### Validate Policy Configuration
 
@@ -177,15 +177,15 @@ eunomia-mcp push mcp_policies.json --overwrite
 | `resources/read` | `mcp:resources:{name}` | `read` | Blocks/forwards the request to the server |
 | `prompts/get`    | `mcp:prompts:{name}`   | `get`  | Blocks/forwards the request to the server |
 
-The middleware extracts contextual attributes from the request and passes them to the decision engine; these attributes can therefore be referenced inside policies to define dynamic rules.
+The middleware extracts contextual attributes from the MCP request and passes them to the decision engine; these attributes can therefore be referenced inside policies to define dynamic rules.
 
-| Attribute        | Type              | Description                                                          |
-| ---------------- | ----------------- | -------------------------------------------------------------------- |
-| `method`         | `str`             | The MCP method being called                                          |
-| `component_type` | `str`             | The type of component being called (`tools`, `prompts`, `resources`) |
-| `name`           | `str`             | The name of the component being called (e.g. `file_read`)            |
-| `uri`            | `str`             | The URI of the component being called (e.g. `mcp:tools:file_read`)   |
-| `arguments`      | `dict` (optional) | The arguments passed to the component being called                   |
+| Attribute        | Type              | Description                                              | Sample value           |
+| ---------------- | ----------------- | -------------------------------------------------------- | ---------------------- |
+| `method`         | `str`             | The MCP method                                           | `tools/list`           |
+| `component_type` | `str`             | The type of component: `tools`, `resources` or `prompts` | `tools`                |
+| `name`           | `str`             | The name of the component                                | `file_read`            |
+| `uri`            | `str`             | The MCP URI of the component                             | `mcp:tools:file_read`  |
+| `arguments`      | `dict` (Optional) | The arguments of the execution operation                 | `{"path": "file.txt"}` |
 
 ### Authentication
 
@@ -247,3 +247,4 @@ logger = logging.getLogger("eunomia_mcp")
 [eunomia-docs-run-server]: https://whataboutyou-ai.github.io/eunomia/get_started/user_guide/run_server
 [example-planetary-weather-mcp]: https://github.com/whataboutyou-ai/eunomia/tree/main/examples/mcp_planetary_weather
 [example-whatsapp-mcp]: https://github.com/whataboutyou-ai/eunomia/tree/main/examples/mcp_whatsapp
+[policy-templates]: https://github.com/whataboutyou-ai/eunomia/tree/main/pkgs/extensions/mcp/templates

--- a/pkgs/extensions/mcp/README.md
+++ b/pkgs/extensions/mcp/README.md
@@ -6,28 +6,53 @@ Add **policy-based authorization** to your [MCP][mcp-docs] servers built on [Fas
 
 ### Features
 
-- 🔒 **Policy-Based Authorization**: Control which agents can access which MCP resources and tools
+- 🔒 **Policy-Based Authorization**: Control which agents can access which MCP tools, resources, and prompts
 - 📊 **Audit Logging**: Track all authorization decisions and violations
 - ⚡ **FastMCP Integration**: One-line middleware integration with FastMCP servers
-- 🔧 **Flexible Configuration**: JSON-based policies with support for complex rules
+- 🔧 **Flexible Configuration**: JSON-based policies for complex dynamic rules with CLI tooling
 - 🎯 **MCP-Aware**: Built-in understanding of MCP protocol (tools, resources, prompts)
 
 ### Architecture
+
+The Eunomia middleware intercepts all MCP requests to your server and automatically maps MCP methods to authorization checks.
+
+#### Listing Operations
+
+The middleware behaves as a filter for listing operations (`tools/list`, `resources/list`, `prompts/list`), hiding to the client components that are not authorized by the defined policies.
 
 ```mermaid
 sequenceDiagram
     participant MCPClient as MCP Client
     participant EunomiaMiddleware as Eunomia Middleware
-    participant MCPServer as MCP Server
+    participant MCPServer as FastMCP Server
     participant EunomiaServer as Eunomia Server
 
-    MCPClient->>EunomiaMiddleware: MCP Request
-    Note over MCPClient, EunomiaMiddleware: Middleware intercepts request to server
+    MCPClient->>EunomiaMiddleware: MCP Listing Request (e.g., tools/list)
+    EunomiaMiddleware->>MCPServer: MCP Listing Request
+    MCPServer-->>EunomiaMiddleware: MCP Listing Response
+    EunomiaMiddleware->>EunomiaServer: Authorization Checks
+    EunomiaServer->>EunomiaMiddleware: Authorization Decisions
+    EunomiaMiddleware-->>MCPClient: Filtered MCP Listing Response
+```
+
+#### Execution Operations
+
+The middleware behaves as a firewall for execution operations (`tools/call`, `resources/read`, `prompts/get`), blocking operations that are not authorized by the defined policies.
+
+```mermaid
+sequenceDiagram
+    participant MCPClient as MCP Client
+    participant EunomiaMiddleware as Eunomia Middleware
+    participant MCPServer as FastMCP Server
+    participant EunomiaServer as Eunomia Server
+
+    MCPClient->>EunomiaMiddleware: MCP Execution Request (e.g., tools/call)
     EunomiaMiddleware->>EunomiaServer: Authorization Check
-    EunomiaServer->>EunomiaMiddleware: Authorization Decision (allow/deny)
+    EunomiaServer->>EunomiaMiddleware: Authorization Decision
     EunomiaMiddleware-->>MCPClient: MCP Unauthorized Error (if denied)
-    EunomiaMiddleware->>MCPServer: MCP Request (if allowed)
-    MCPServer-->>MCPClient: MCP Response (if allowed)
+    EunomiaMiddleware->>MCPServer: MCP Execution Request (if allowed)
+    MCPServer-->>EunomiaMiddleware: MCP Execution Response (if allowed)
+    EunomiaMiddleware-->>MCPClient: MCP Execution Response (if allowed)
 ```
 
 ### Installation
@@ -152,7 +177,7 @@ eunomia-mcp push mcp_policies.json --overwrite
 | `resources/read` | `mcp:resources:{name}` | `read` | Blocks/forwards the request to the server |
 | `prompts/get`    | `mcp:prompts:{name}`   | `get`  | Blocks/forwards the request to the server |
 
-The Middleware extracts additional attributes from the request that are passed to the decision engine that can be referenced in policies. The attributes are in the form of:
+The middleware extracts contextual attributes from the request and passes them to the decision engine; these attributes can therefore be referenced inside policies to define dynamic rules.
 
 | Attribute        | Type              | Description                                                          |
 | ---------------- | ----------------- | -------------------------------------------------------------------- |

--- a/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
@@ -6,33 +6,24 @@ from eunomia_sdk import EunomiaClient
 DEFAULT_POLICY = {
     "version": "1.0",
     "name": "mcp-default-policy",
+    "description": "Default policy for a MCP server",
     "default_effect": enums.PolicyEffect.DENY,
     "rules": [
         {
-            "name": "allow-mcp-discovery",
+            "name": "unrestricted-listing",
+            "description": "All principals can list tools, resources, and prompts",
             "effect": enums.PolicyEffect.ALLOW,
             "principal_conditions": [],
-            "resource_conditions": [
-                {
-                    "path": "attributes.mcp_method",
-                    "operator": enums.ConditionOperator.IN,
-                    "value": ["tools/list", "resources/list", "prompts/list"],
-                },
-            ],
-            "actions": ["access"],
+            "resource_conditions": [],
+            "actions": ["list"],
         },
         {
-            "name": "allow-mcp-operations",
+            "name": "unrestricted-execution",
+            "description": "All principals can call tools, read resources, and get prompts",
             "effect": enums.PolicyEffect.ALLOW,
             "principal_conditions": [],
-            "resource_conditions": [
-                {
-                    "path": "attributes.mcp_method",
-                    "operator": enums.ConditionOperator.IN,
-                    "value": ["tools/call", "resources/read", "prompts/get"],
-                },
-            ],
-            "actions": ["execute", "read"],
+            "resource_conditions": [],
+            "actions": ["call", "read", "get"],
         },
     ],
 }

--- a/pkgs/extensions/mcp/src/eunomia_mcp/middleware.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/middleware.py
@@ -67,7 +67,7 @@ class EunomiaMcpMiddleware(Middleware):
             uri=uri, attributes=mcp_attributes.model_dump(exclude_none=True)
         )
 
-    def _authorize_call(
+    def _authorize_execution(
         self, context: MiddlewareContext, component: FastMCPComponent
     ) -> None:
         if not component.enabled:
@@ -97,7 +97,7 @@ class EunomiaMcpMiddleware(Middleware):
         if not result.allowed:
             raise ToolError(f"Access denied: {result.reason}")
 
-    def _authorize_list(
+    def _authorize_listing(
         self, context: MiddlewareContext, components: list[FastMCPComponent]
     ) -> list[FastMCPComponent]:
         if components:
@@ -158,7 +158,7 @@ class EunomiaMcpMiddleware(Middleware):
         call_next: CallNext[types.CallToolRequestParams, types.CallToolResult],
     ) -> types.CallToolResult:
         tool = await context.fastmcp_context.fastmcp.get_tool(context.message.name)
-        self._authorize_call(context, tool)
+        self._authorize_execution(context, tool)
         result = await call_next(context)
         return result
 
@@ -170,7 +170,7 @@ class EunomiaMcpMiddleware(Middleware):
         resource = await context.fastmcp_context.fastmcp.get_resource(
             context.message.uri
         )
-        self._authorize_call(context, resource)
+        self._authorize_execution(context, resource)
         return await call_next(context)
 
     async def on_get_prompt(
@@ -179,7 +179,7 @@ class EunomiaMcpMiddleware(Middleware):
         call_next: CallNext[types.GetPromptRequestParams, types.GetPromptResult],
     ) -> types.GetPromptResult:
         prompt = await context.fastmcp_context.fastmcp.get_prompt(context.message.name)
-        self._authorize_call(context, prompt)
+        self._authorize_execution(context, prompt)
         return await call_next(context)
 
     async def on_list_tools(
@@ -188,7 +188,7 @@ class EunomiaMcpMiddleware(Middleware):
         call_next: CallNext[types.ListToolsRequest, list[Tool]],
     ) -> list[Tool]:
         result = await call_next(context)
-        return self._authorize_list(context, result)
+        return self._authorize_listing(context, result)
 
     async def on_list_resources(
         self,
@@ -196,7 +196,7 @@ class EunomiaMcpMiddleware(Middleware):
         call_next: CallNext[types.ListResourcesRequest, list[Resource]],
     ) -> list[Resource]:
         result = await call_next(context)
-        return self._authorize_list(context, result)
+        return self._authorize_listing(context, result)
 
     async def on_list_prompts(
         self,
@@ -204,4 +204,4 @@ class EunomiaMcpMiddleware(Middleware):
         call_next: CallNext[types.ListPromptsRequest, list[Prompt]],
     ) -> list[Prompt]:
         result = await call_next(context)
-        return self._authorize_list(context, result)
+        return self._authorize_listing(context, result)

--- a/pkgs/extensions/mcp/src/eunomia_mcp/middleware.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/middleware.py
@@ -159,8 +159,7 @@ class EunomiaMcpMiddleware(Middleware):
     ) -> types.CallToolResult:
         tool = await context.fastmcp_context.fastmcp.get_tool(context.message.name)
         self._authorize_execution(context, tool)
-        result = await call_next(context)
-        return result
+        return await call_next(context)
 
     async def on_read_resource(
         self,
@@ -187,21 +186,21 @@ class EunomiaMcpMiddleware(Middleware):
         context: MiddlewareContext[types.ListToolsRequest],
         call_next: CallNext[types.ListToolsRequest, list[Tool]],
     ) -> list[Tool]:
-        result = await call_next(context)
-        return self._authorize_listing(context, result)
+        tools = await call_next(context)
+        return self._authorize_listing(context, tools)
 
     async def on_list_resources(
         self,
         context: MiddlewareContext[types.ListResourcesRequest],
         call_next: CallNext[types.ListResourcesRequest, list[Resource]],
     ) -> list[Resource]:
-        result = await call_next(context)
-        return self._authorize_listing(context, result)
+        resources = await call_next(context)
+        return self._authorize_listing(context, resources)
 
     async def on_list_prompts(
         self,
         context: MiddlewareContext[types.ListPromptsRequest],
         call_next: CallNext[types.ListPromptsRequest, list[Prompt]],
     ) -> list[Prompt]:
-        result = await call_next(context)
-        return self._authorize_listing(context, result)
+        prompts = await call_next(context)
+        return self._authorize_listing(context, prompts)

--- a/pkgs/extensions/mcp/templates/001_list_call_tools.json
+++ b/pkgs/extensions/mcp/templates/001_list_call_tools.json
@@ -1,0 +1,55 @@
+{
+  "version": "1.0",
+  "name": "mcp-template-policy-001",
+  "description": "Template policy for tool listing and calling tools",
+  "default_effect": "deny",
+  "rules": [
+    {
+      "name": "list-read-write-tools",
+      "description": "Allow listing the read and write tools",
+      "effect": "allow",
+      "principal_conditions": [],
+      "resource_conditions": [
+        {
+          "path": "attributes.name",
+          "operator": "in",
+          "value": ["read_file", "write_file"]
+        }
+      ],
+      "actions": ["list"]
+    },
+    {
+      "name": "call-read-tool",
+      "description": "Allow calling the read tool",
+      "effect": "allow",
+      "principal_conditions": [],
+      "resource_conditions": [
+        {
+          "path": "attributes.name",
+          "operator": "equals",
+          "value": "read_file"
+        }
+      ],
+      "actions": ["call"]
+    },
+    {
+      "name": "call-write-tool-for-notes",
+      "description": "Allow calling the write tool only for files in the user's notes directory",
+      "effect": "allow",
+      "principal_conditions": [],
+      "resource_conditions": [
+        {
+          "path": "attributes.name",
+          "operator": "equals",
+          "value": "write_file"
+        },
+        {
+          "path": "attributes.arguments.path",
+          "operator": "startswith",
+          "value": "/home/user/notes/"
+        }
+      ],
+      "actions": ["call"]
+    }
+  ]
+}

--- a/pkgs/extensions/mcp/templates/002_agent.json
+++ b/pkgs/extensions/mcp/templates/002_agent.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0",
+  "name": "mcp-template-policy-002",
+  "description": "Template policy for restricting access to a specific agent only",
+  "default_effect": "deny",
+  "rules": [
+    {
+      "name": "allow-cursor-agents",
+      "description": "Allow all operations for Cursor agents only",
+      "effect": "allow",
+      "principal_conditions": [
+        {
+          "path": "attributes.user_agent",
+          "operator": "contains",
+          "value": "Cursor"
+        }
+      ],
+      "resource_conditions": [],
+      "actions": ["list", "call", "read", "get"]
+    }
+  ]
+}

--- a/tests/eunomia_mcp/test_cli.py
+++ b/tests/eunomia_mcp/test_cli.py
@@ -462,16 +462,16 @@ class TestConstants:
         assert len(DEFAULT_POLICY["rules"]) == 2
 
         # Check first rule
-        discovery_rule = DEFAULT_POLICY["rules"][0]
-        assert discovery_rule["name"] == "allow-mcp-discovery"
-        assert discovery_rule["effect"] == enums.PolicyEffect.ALLOW
-        assert discovery_rule["actions"] == ["access"]
+        listing_rule = DEFAULT_POLICY["rules"][0]
+        assert listing_rule["name"] == "unrestricted-listing"
+        assert listing_rule["effect"] == enums.PolicyEffect.ALLOW
+        assert listing_rule["actions"] == ["list"]
 
         # Check second rule
-        ops_rule = DEFAULT_POLICY["rules"][1]
-        assert ops_rule["name"] == "allow-mcp-operations"
-        assert ops_rule["effect"] == enums.PolicyEffect.ALLOW
-        assert ops_rule["actions"] == ["execute", "read"]
+        execution_rule = DEFAULT_POLICY["rules"][1]
+        assert execution_rule["name"] == "unrestricted-execution"
+        assert execution_rule["effect"] == enums.PolicyEffect.ALLOW
+        assert execution_rule["actions"] == ["call", "read", "get"]
 
     def test_sample_server_code_structure(self):
         """Test that SAMPLE_SERVER_CODE contains expected components."""


### PR DESCRIPTION
## Summary
- Provided template policies for most common scenarios
- Revised MCP docs with two separate mermaid diagrams, one for listing ops and one for execution ops
- Corrected default policy generated by `eunomia-mcp init` command