### PR TITLE
Fix mutable default argument bugs in Python SDK and server components

### DIFF
--- a/pkgs/extensions/langchain/src/eunomia_langchain/document_loader.py
+++ b/pkgs/extensions/langchain/src/eunomia_langchain/document_loader.py
@@ -41,8 +41,11 @@ class EunomiaLoader:
         self._client = EunomiaClient(endpoint=endpoint, api_key=api_key)
 
     def _process_document_sync(
-        self, doc: Document, additional_metadata: dict = {}
+        self, doc: Document, additional_metadata: dict | None = None
     ) -> Document:
+        if additional_metadata is None:
+            additional_metadata = {}
+            
         if not hasattr(doc, "metadata") or doc.metadata is None:
             doc.metadata = {}
         doc.metadata.update(additional_metadata)
@@ -54,8 +57,11 @@ class EunomiaLoader:
         return doc
 
     async def _process_document_async(
-        self, doc: Document, additional_metadata: dict = {}
+        self, doc: Document, additional_metadata: dict | None = None
     ) -> Document:
+        if additional_metadata is None:
+            additional_metadata = {}
+            
         if not hasattr(doc, "metadata") or doc.metadata is None:
             doc.metadata = {}
         doc.metadata.update(additional_metadata)
@@ -71,7 +77,7 @@ class EunomiaLoader:
         return doc
 
     async def alazy_load(
-        self, additional_metadata: dict = {}
+        self, additional_metadata: dict | None = None
     ) -> AsyncIterator[Document]:
         """Load documents lazily and asynchronously, registering them with the Eunomia server.
 
@@ -99,11 +105,14 @@ class EunomiaLoader:
         >>>
         >>> asyncio.run(process_docs())
         """
+        if additional_metadata is None:
+            additional_metadata = {}
+            
         async for doc in self._loader.alazy_load():
             processed_doc = await self._process_document_async(doc, additional_metadata)
             yield processed_doc
 
-    async def aload(self, additional_metadata: dict = {}) -> List[Document]:
+    async def aload(self, additional_metadata: dict | None = None) -> List[Document]:
         """Load documents asynchronously and register them with the Eunomia server.
 
         Parameters
@@ -125,6 +134,9 @@ class EunomiaLoader:
         >>> wrapped_loader = EunomiaLoader(loader)
         >>> docs = asyncio.run(wrapped_loader.aload(additional_metadata={"group": "financials"}))
         """
+        if additional_metadata is None:
+            additional_metadata = {}
+            
         documents = await self._loader.aload()
         processed_docs = [
             await self._process_document_async(doc, additional_metadata)
@@ -132,7 +144,7 @@ class EunomiaLoader:
         ]
         return processed_docs
 
-    def lazy_load(self, additional_metadata: dict = {}) -> Iterator[Document]:
+    def lazy_load(self, additional_metadata: dict | None = None) -> Iterator[Document]:
         """Load documents lazily and synchronously, registering them with the Eunomia server.
 
         Parameters
@@ -154,11 +166,14 @@ class EunomiaLoader:
         >>> for doc in wrapped_loader.lazy_load(additional_metadata={"group": "financials"}):
         ...     process_document(doc)
         """
+        if additional_metadata is None:
+            additional_metadata = {}
+            
         for doc in self._loader.lazy_load():
             processed_doc = self._process_document_sync(doc, additional_metadata)
             yield processed_doc
 
-    def load(self, additional_metadata: dict = {}) -> List[Document]:
+    def load(self, additional_metadata: dict | None = None) -> List[Document]:
         """Load documents synchronously and register them with the Eunomia server.
 
         Parameters
@@ -179,6 +194,9 @@ class EunomiaLoader:
         >>> wrapped_loader = EunomiaLoader(loader)
         >>> docs = wrapped_loader.load(additional_metadata={"group": "financials"})
         """
+        if additional_metadata is None:
+            additional_metadata = {}
+            
         documents = self._loader.load()
         processed_docs = [
             self._process_document_sync(doc, additional_metadata) for doc in documents

--- a/pkgs/sdks/python/src/eunomia_sdk/client.py
+++ b/pkgs/sdks/python/src/eunomia_sdk/client.py
@@ -48,8 +48,8 @@ class EunomiaClient:
         self,
         principal_uri: str | None = None,
         resource_uri: str | None = None,
-        principal_attributes: dict = {},
-        resource_attributes: dict = {},
+        principal_attributes: dict | None = None,
+        resource_attributes: dict | None = None,
         action: str = "access",
     ) -> schemas.CheckResponse:
         """
@@ -78,6 +78,11 @@ class EunomiaClient:
         httpx.HTTPStatusError
             If the HTTP request returns an unsuccessful status code.
         """
+        if principal_attributes is None:
+            principal_attributes = {}
+        if resource_attributes is None:
+            resource_attributes = {}
+            
         request = schemas.CheckRequest(
             principal=schemas.PrincipalCheck(
                 uri=principal_uri, attributes=principal_attributes
@@ -292,7 +297,7 @@ class EunomiaClient:
         return response.json()
 
     def issue_passport(
-        self, uri: str, attributes: dict = {}, ttl: int | None = None
+        self, uri: str, attributes: dict | None = None, ttl: int | None = None
     ) -> schemas.PassportIssueResponse:
         """
         Issue a passport JWT token for the given URI.
@@ -316,6 +321,9 @@ class EunomiaClient:
         httpx.HTTPStatusError
             If the HTTP request returns an unsuccessful status code.
         """
+        if attributes is None:
+            attributes = {}
+            
         request = schemas.PassportIssueRequest(uri=uri, attributes=attributes, ttl=ttl)
         response = self.client.post(
             "/admin/fetchers/passport/issue", json=request.model_dump()

--- a/src/eunomia/fetchers/passport/main.py
+++ b/src/eunomia/fetchers/passport/main.py
@@ -61,7 +61,7 @@ class PassportFetcher(BaseFetcher):
         logger.info(message, extra={"audit_data": audit_data})
 
     def issue_passport(
-        self, uri: str, attributes: dict = {}, ttl: int | None = None
+        self, uri: str, attributes: dict | None = None, ttl: int | None = None
     ) -> tuple[str, str, int]:
         """
         Issue a passport JWT token for the given URI.
@@ -80,6 +80,9 @@ class PassportFetcher(BaseFetcher):
             tuple[str, str, int]
                 Tuple of (token, passport_id, ttl)
         """
+        if attributes is None:
+            attributes = {}
+            
         passport_id = None
         try:
             if self.config.requires_registry:


### PR DESCRIPTION
Replace potentially dangerous mutable default arguments (dict={}) with None pattern to prevent shared state between function calls. This addresses production-critical bugs where passport attributes and metadata could leak between requests.

Changes:
 - Python SDK: Fix issue_passport() and check() methods in client.py
 - Server: Fix issue_passport() method in passport fetcher
 - LangChain: Fix document processing methods in EunomiaLoader