### PR TITLE
Generate custom policy from MCP server

### DIFF
--- a/docs/mcp_middleware/policies.md
+++ b/docs/mcp_middleware/policies.md
@@ -55,14 +55,14 @@ Workflow:
 
 The middleware automatically maps MCP methods to authorization checks:
 
-| MCP Method       | Resource URI           | Action | Middleware behavior                       |
-| ---------------- | ---------------------- | ------ | ----------------------------------------- |
-| `tools/list`     | `mcp:tools:{name}`     | `list` | Filters the server's response             |
-| `resources/list` | `mcp:resources:{name}` | `list` | Filters the server's response             |
-| `prompts/list`   | `mcp:prompts:{name}`   | `list` | Filters the server's response             |
-| `tools/call`     | `mcp:tools:{name}`     | `call` | Blocks/forwards the request to the server |
-| `resources/read` | `mcp:resources:{name}` | `read` | Blocks/forwards the request to the server |
-| `prompts/get`    | `mcp:prompts:{name}`   | `get`  | Blocks/forwards the request to the server |
+| MCP Method       | Resource URI           | Action    | Middleware behavior                       |
+| ---------------- | ---------------------- | --------- | ----------------------------------------- |
+| `tools/list`     | `mcp:tools:{name}`     | `list`    | Filters the server's response             |
+| `tools/call`     | `mcp:tools:{name}`     | `execute` | Blocks/forwards the request to the server |
+| `resources/list` | `mcp:resources:{name}` | `list`    | Filters the server's response             |
+| `resources/read` | `mcp:resources:{name}` | `execute` | Blocks/forwards the request to the server |
+| `prompts/list`   | `mcp:prompts:{name}`   | `list`    | Filters the server's response             |
+| `prompts/get`    | `mcp:prompts:{name}`   | `execute` | Blocks/forwards the request to the server |
 
 ### Contextual Attributes
 

--- a/docs/mcp_middleware/policies.md
+++ b/docs/mcp_middleware/policies.md
@@ -10,10 +10,10 @@ Use the `eunomia-mcp` CLI in your terminal to manage your MCP authorization poli
 # Create a default policy configuration file
 eunomia-mcp init
 
-# Create policy configuration file with custom name
-eunomia-mcp init --policy-file my_policies.json
+# Create a custom policy configuration file from your FastMCP server instance
+eunomia-mcp init --custom-mcp "server.py:mcp"
 
-# Generate both policy configuration file and a sample MCP server
+# Generate both policy configuration file and a sample FastMCP server with Eunomia authorization
 eunomia-mcp init --sample
 ```
 
@@ -42,12 +42,17 @@ eunomia-mcp push mcp_policies.json --overwrite
 
 Workflow:
 
-1. **Initialize**: `eunomia-mcp init`
-2. **Customize**: Edit generated policy file
-3. **Validate**: `eunomia-mcp validate mcp_policies.json`
-4. **Start Server**: `eunomia server`
-5. **Deploy**: `eunomia-mcp push mcp_policies.json`
-6. **Run**: Run your MCP server with middleware
+1.  **Initialize**: `eunomia-mcp init`
+
+    !!! tip
+
+        Use `--custom-mcp` for a policy customized for your MCP server!
+
+2.  **Customize**: Edit generated policy file
+3.  **Validate**: `eunomia-mcp validate mcp_policies.json`
+4.  **Start Server**: Start Eunomia server (with `eunomia server` or other methods)
+5.  **Deploy**: `eunomia-mcp push mcp_policies.json`
+6.  **Run**: Run your MCP server with middleware
 
 ## MCP Context Extraction
 

--- a/examples/mcp_planetary_weather/mcp_policies.json
+++ b/examples/mcp_planetary_weather/mcp_policies.json
@@ -4,8 +4,8 @@
   "default_effect": "deny",
   "rules": [
     {
-      "name": "list-and-call",
-      "description": "All principals can list and call the specified tools",
+      "name": "list-and-execute",
+      "description": "All principals can list and execute the specified tools",
       "effect": "allow",
       "principal_conditions": [],
       "resource_conditions": [
@@ -15,7 +15,7 @@
           "value": ["get_venus_weather", "get_mars_weather"]
         }
       ],
-      "actions": ["list", "call"]
+      "actions": ["list", "execute"]
     },
     {
       "name": "list-only",
@@ -32,8 +32,8 @@
       "actions": ["list"]
     },
     {
-      "name": "restricted-call",
-      "description": "All principals can call the specified tool with restricted arguments",
+      "name": "restricted-execute",
+      "description": "All principals can execute the specified tool with restricted arguments",
       "effect": "allow",
       "principal_conditions": [],
       "resource_conditions": [
@@ -48,7 +48,7 @@
           "value": "night"
         }
       ],
-      "actions": ["call"]
+      "actions": ["execute"]
     }
   ]
 }

--- a/examples/mcp_whatsapp/mcp_policies.json
+++ b/examples/mcp_whatsapp/mcp_policies.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "allow-read-tools",
-      "description": "Allow Cursor to call read-only tools",
+      "description": "Allow Cursor to execute read-only tools",
       "effect": "allow",
       "principal_conditions": [
         {
@@ -30,11 +30,11 @@
           "value": ["send_message", "send_file", "send_audio_message"]
         }
       ],
-      "actions": ["call"]
+      "actions": ["execute"]
     },
     {
       "name": "restrict-send-tools",
-      "description": "Allow Cursor to call send-only tools to specific recipients only",
+      "description": "Allow Cursor to execute send-only tools to specific recipients only",
       "effect": "allow",
       "principal_conditions": [
         {
@@ -55,7 +55,7 @@
           "value": ["PHONE_NUMBER_1", "PHONE_NUMBER_2", "PHONE_NUMBER_3"]
         }
       ],
-      "actions": ["call"]
+      "actions": ["execute"]
     }
   ]
 }

--- a/pkgs/core/src/eunomia_core/schemas/policy.py
+++ b/pkgs/core/src/eunomia_core/schemas/policy.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from eunomia_core.enums.policy import ConditionOperator, PolicyEffect
+from eunomia_core.utils import slugify
 
 
 class Condition(BaseModel):
@@ -47,6 +48,11 @@ class Rule(BaseModel):
             return json.loads(v)
         return v
 
+    @field_validator("name", mode="before")
+    @classmethod
+    def slugify(cls, v: str) -> str:
+        return slugify(v)
+
 
 class Policy(BaseModel):
     version: str = Field("1.0", description="Version of the policy")
@@ -58,6 +64,11 @@ class Policy(BaseModel):
     default_effect: PolicyEffect = Field(
         PolicyEffect.DENY, description="Default effect if no rules match"
     )
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def slugify(cls, v: str) -> str:
+        return slugify(v)
 
     model_config = ConfigDict(from_attributes=True, extra="forbid")
 

--- a/pkgs/core/src/eunomia_core/schemas/policy.py
+++ b/pkgs/core/src/eunomia_core/schemas/policy.py
@@ -53,8 +53,11 @@ class Rule(BaseModel):
 
     @field_validator("name", mode="before")
     @classmethod
-    def slugify(cls, v: str) -> str:
-        return slugify(v)
+    def slugify_name(cls, v: str) -> str:
+        result = slugify(v)
+        if not result:
+            raise ValueError(f"Cannot create valid slug from: {v}")
+        return result
 
 
 class Policy(BaseModel):
@@ -70,8 +73,11 @@ class Policy(BaseModel):
 
     @field_validator("name", mode="before")
     @classmethod
-    def slugify(cls, v: str) -> str:
-        return slugify(v)
+    def slugify_name(cls, v: str) -> str:
+        result = slugify(v)
+        if not result:
+            raise ValueError(f"Cannot create valid slug from: {v}")
+        return result
 
     model_config = ConfigDict(from_attributes=True, extra="forbid")
 

--- a/pkgs/core/src/eunomia_core/schemas/policy.py
+++ b/pkgs/core/src/eunomia_core/schemas/policy.py
@@ -15,7 +15,7 @@ class Condition(BaseModel):
     operator: ConditionOperator = Field(..., description="Comparison operator")
     value: Any = Field(..., description="Value to compare against")
 
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
 
     @field_validator("value", mode="before")
     @classmethod
@@ -30,6 +30,9 @@ class Condition(BaseModel):
 
 class Rule(BaseModel):
     name: str = Field(..., description="Name of the rule")
+    description: Optional[str] = Field(
+        None, description="Human-readable description of the rule"
+    )
     effect: PolicyEffect = Field(..., description="Effect when the rule matches")
     principal_conditions: list[Condition] = Field(
         default_factory=list, description="Conditions applied to principal"
@@ -39,7 +42,7 @@ class Rule(BaseModel):
     )
     actions: list[str] = Field(..., description="All actions evaluated by the rule")
 
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
 
     @field_validator("actions", mode="before")
     @classmethod

--- a/pkgs/core/src/eunomia_core/utils.py
+++ b/pkgs/core/src/eunomia_core/utils.py
@@ -1,5 +1,22 @@
+import re
+import unicodedata
 import uuid
 
 
 def generate_uri() -> str:
     return str(uuid.uuid4())
+
+
+def slugify(s: str) -> str:
+    s = s.lower()
+
+    # Normalize Unicode characters (e.g., emojis, accented characters)
+    s = unicodedata.normalize("NFKD", s).encode("ascii", "ignore").decode("utf-8")
+
+    # Replace any character that is not an alphanumeric or hyphen with a hyphen
+    s = re.sub(r"[^\w-]", "-", s)
+
+    # Replace multiple consecutive hyphens with a single hyphen
+    s = re.sub(r"-+", "-", s)
+
+    return s.strip("-")

--- a/pkgs/extensions/mcp/README.md
+++ b/pkgs/extensions/mcp/README.md
@@ -169,14 +169,14 @@ eunomia-mcp push mcp_policies.json --overwrite
 
 ### MCP Method Mappings
 
-| MCP Method       | Resource URI           | Action | Middleware behavior                       |
-| ---------------- | ---------------------- | ------ | ----------------------------------------- |
-| `tools/list`     | `mcp:tools:{name}`     | `list` | Filters the server's response             |
-| `resources/list` | `mcp:resources:{name}` | `list` | Filters the server's response             |
-| `prompts/list`   | `mcp:prompts:{name}`   | `list` | Filters the server's response             |
-| `tools/call`     | `mcp:tools:{name}`     | `call` | Blocks/forwards the request to the server |
-| `resources/read` | `mcp:resources:{name}` | `read` | Blocks/forwards the request to the server |
-| `prompts/get`    | `mcp:prompts:{name}`   | `get`  | Blocks/forwards the request to the server |
+| MCP Method       | Resource URI           | Action    | Middleware behavior                       |
+| ---------------- | ---------------------- | --------- | ----------------------------------------- |
+| `tools/list`     | `mcp:tools:{name}`     | `list`    | Filters the server's response             |
+| `tools/call`     | `mcp:tools:{name}`     | `execute` | Blocks/forwards the request to the server |
+| `resources/list` | `mcp:resources:{name}` | `list`    | Filters the server's response             |
+| `resources/read` | `mcp:resources:{name}` | `execute` | Blocks/forwards the request to the server |
+| `prompts/list`   | `mcp:prompts:{name}`   | `list`    | Filters the server's response             |
+| `prompts/get`    | `mcp:prompts:{name}`   | `execute` | Blocks/forwards the request to the server |
 
 The middleware extracts contextual attributes from the MCP request and passes them to the decision engine; these attributes can therefore be referenced inside policies to define dynamic rules.
 

--- a/pkgs/extensions/mcp/README.md
+++ b/pkgs/extensions/mcp/README.md
@@ -85,7 +85,7 @@ def add(a: int, b: int) -> int:
 # Add Eunomia authorization middleware
 middleware = EunomiaMcpMiddleware()
 
-# Create ASGI app with authorization
+# Apply middleware to MCP server
 mcp.add_middleware(middleware)
 
 if __name__ == "__main__":

--- a/pkgs/extensions/mcp/README.md
+++ b/pkgs/extensions/mcp/README.md
@@ -134,10 +134,10 @@ Use the `eunomia-mcp` CLI in your terminal to manage your MCP authorization poli
 # Create a default policy configuration file
 eunomia-mcp init
 
-# Create policy configuration file with custom name
-eunomia-mcp init --policy-file my_policies.json
+# Create a custom policy configuration file from your FastMCP server instance
+eunomia-mcp init --custom-mcp "server.py:mcp"
 
-# Generate both policy configuration file and a sample MCP server
+# Generate both policy configuration file and a sample FastMCP server with Eunomia authorization
 eunomia-mcp init --sample
 ```
 

--- a/pkgs/extensions/mcp/src/eunomia_mcp/cli/main.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/cli/main.py
@@ -55,7 +55,7 @@ def init(
         raise typer.Exit(1)
 
     with open(policy_file, "w") as f:
-        json.dump(DEFAULT_POLICY, f, indent=2)
+        json.dump(DEFAULT_POLICY.model_dump(exclude_none=True), f, indent=2)
     typer.echo(f"Generated policy configuration file: {policy_file}")
 
     if sample:

--- a/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
@@ -1,7 +1,12 @@
+import asyncio
+import importlib.util
 import os
+import sys
 
 from eunomia_core import enums, schemas
 from eunomia_sdk import EunomiaClient
+from fastmcp import FastMCP
+from fastmcp.utilities.components import FastMCPComponent
 
 DEFAULT_POLICY = schemas.Policy(
     version="1.0",
@@ -35,7 +40,7 @@ def add(a: int, b: int) -> int:
 # Add Eunomia authorization middleware
 middleware = EunomiaMcpMiddleware()
 
-# Create ASGI app with authorization
+# Apply middleware to MCP server
 mcp.add_middleware(middleware)
 
 if __name__ == "__main__":
@@ -82,3 +87,148 @@ def push_policy_config(
             _ = client.delete_policy(p.name)
 
     _ = client.create_policy(new_policy)
+
+
+def load_mcp_instance(mcp_path: str) -> FastMCP:
+    """
+    Load a FastMCP instance from a module path.
+
+    Args:
+        mcp_path: Path in format "module.path:variable_name", "path/to/file:variable_name" or "path/to/file.py:variable_name"
+
+    Returns:
+        FastMCP instance
+
+    Raises:
+        ValueError: If path format is invalid or instance is not found
+        ImportError: If module cannot be imported
+        TypeError: If the loaded object is not a FastMCP instance
+    """
+    if ":" not in mcp_path:
+        raise ValueError(
+            f"Invalid MCP path format: {mcp_path}. "
+            "Expected format: 'module.path:variable_name'"
+        )
+
+    module_path, variable_name = mcp_path.split(":", 1)
+
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError:
+        # If direct import fails, try loading as file path
+        full_path = module_path if module_path.endswith(".py") else module_path + ".py"
+        if os.path.exists(full_path):
+            spec = importlib.util.spec_from_file_location("custom_mcp", full_path)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Cannot load module from {full_path}")
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["custom_mcp"] = module
+            spec.loader.exec_module(module)
+        else:
+            raise ImportError(f"Cannot import module: {module_path}")
+
+    if not hasattr(module, variable_name):
+        raise ValueError(
+            f"Variable '{variable_name}' not found in module '{module_path}'"
+        )
+    mcp_instance = getattr(module, variable_name)
+
+    if not isinstance(mcp_instance, FastMCP):
+        raise TypeError(
+            f"Object at {mcp_path} is not a FastMCP instance. "
+            f"Got {type(mcp_instance).__name__}"
+        )
+
+    return mcp_instance
+
+
+def custom_list_rule(component_type: str, component_names: list[str]) -> schemas.Rule:
+    return schemas.Rule(
+        name=f"list-{component_type}",
+        description=f"List all {component_type} (tip: exclude from `attributes.name`'s values the ones that you want to hide from the MCP client)",
+        effect=enums.PolicyEffect.ALLOW,
+        principal_conditions=[],
+        resource_conditions=[
+            schemas.Condition(
+                path="attributes.component_type",
+                operator=enums.ConditionOperator.EQUALS,
+                value=component_type,
+            ),
+            schemas.Condition(
+                path="attributes.name",
+                operator=enums.ConditionOperator.IN,
+                value=component_names,
+            ),
+        ],
+        actions=["list"],
+    )
+
+
+def custom_execute_rules(
+    component_type: str, components: list[FastMCPComponent]
+) -> list[schemas.Rule]:
+    rules = []
+    for component in components:
+        rules.append(
+            schemas.Rule(
+                name=f"execute-{component_type}-{component.name}",
+                description=f"Execute {component_type}:{component.name} (tip: add additional conditions on `attributes.arguments.[:path]` to restrict this execution)",
+                effect=enums.PolicyEffect.ALLOW,
+                principal_conditions=[],
+                resource_conditions=[
+                    schemas.Condition(
+                        path="attributes.component_type",
+                        operator=enums.ConditionOperator.EQUALS,
+                        value=component_type,
+                    ),
+                    schemas.Condition(
+                        path="attributes.name",
+                        operator=enums.ConditionOperator.EQUALS,
+                        value=component.name,
+                    ),
+                ],
+                actions=["execute"],
+            )
+        )
+    return rules
+
+
+async def generate_custom_policy_from_mcp(mcp: FastMCP) -> schemas.Policy:
+    """
+    Generate a custom policy by analyzing the content of an MCP server.
+
+    Args:
+        mcp: the MCP server
+
+    Returns:
+        A policy object
+    """
+    rules: list[schemas.Rule] = []
+
+    tools, resources, prompts = await asyncio.gather(
+        mcp.get_tools(), mcp.get_resources(), mcp.get_prompts()
+    )
+
+    if tools:
+        rules.extend(
+            [custom_list_rule("tools", list(tools.keys()))]
+            + custom_execute_rules("tools", list(tools.values()))
+        )
+    if resources:
+        rules.extend(
+            [custom_list_rule("resources", list(resources.keys()))]
+            + custom_execute_rules("resources", list(resources.values()))
+        )
+    if prompts:
+        rules.extend(
+            [custom_list_rule("prompts", list(prompts.keys()))]
+            + custom_execute_rules("prompts", list(prompts.values()))
+        )
+
+    return schemas.Policy(
+        version="1.0",
+        name=f"{mcp.name}-generated-policy",
+        description=f"Generated policy for MCP server: {mcp.name}",
+        default_effect=enums.PolicyEffect.DENY,
+        rules=rules,
+    )

--- a/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
@@ -3,30 +3,22 @@ import os
 from eunomia_core import enums, schemas
 from eunomia_sdk import EunomiaClient
 
-DEFAULT_POLICY = {
-    "version": "1.0",
-    "name": "mcp-default-policy",
-    "description": "Default policy for a MCP server",
-    "default_effect": enums.PolicyEffect.DENY,
-    "rules": [
-        {
-            "name": "unrestricted-listing",
-            "description": "All principals can list tools, resources, and prompts",
-            "effect": enums.PolicyEffect.ALLOW,
-            "principal_conditions": [],
-            "resource_conditions": [],
-            "actions": ["list"],
-        },
-        {
-            "name": "unrestricted-execution",
-            "description": "All principals can call tools, read resources, and get prompts",
-            "effect": enums.PolicyEffect.ALLOW,
-            "principal_conditions": [],
-            "resource_conditions": [],
-            "actions": ["call", "read", "get"],
-        },
+DEFAULT_POLICY = schemas.Policy(
+    version="1.0",
+    name="mcp-default-policy",
+    description="Default policy for a MCP server",
+    default_effect=enums.PolicyEffect.DENY,
+    rules=[
+        schemas.Rule(
+            name="unrestricted-access",
+            description="All principals can list and execute tools, resources, and prompts",
+            effect=enums.PolicyEffect.ALLOW,
+            principal_conditions=[],
+            resource_conditions=[],
+            actions=["list", "execute"],
+        ),
     ],
-}
+)
 
 SAMPLE_SERVER_CODE = '''
 from fastmcp import FastMCP

--- a/pkgs/extensions/mcp/src/eunomia_mcp/middleware.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/middleware.py
@@ -73,8 +73,8 @@ class EunomiaMcpMiddleware(Middleware):
         if not component.enabled:
             raise ToolError(f"Access denied: {component.name} is disabled")
 
+        action = "execute"
         principal = self._extract_principal()
-        action = context.method.split("/")[1]
         resource = self._extract_resource(context, component)
 
         result = self._eunomia_client.check(
@@ -101,8 +101,8 @@ class EunomiaMcpMiddleware(Middleware):
         self, context: MiddlewareContext, components: list[FastMCPComponent]
     ) -> list[FastMCPComponent]:
         if components:
+            action = "list"
             principal = self._extract_principal()
-            action = context.method.split("/")[1]
 
             # Construct requests for bulk check
             resources = [self._extract_resource(context, c) for c in components]

--- a/pkgs/extensions/mcp/templates/001_list_execute_tools.json
+++ b/pkgs/extensions/mcp/templates/001_list_execute_tools.json
@@ -19,8 +19,8 @@
       "actions": ["list"]
     },
     {
-      "name": "call-read-tool",
-      "description": "Allow calling the read tool",
+      "name": "execute-read-tool",
+      "description": "Allow executing the read tool",
       "effect": "allow",
       "principal_conditions": [],
       "resource_conditions": [
@@ -30,11 +30,11 @@
           "value": "read_file"
         }
       ],
-      "actions": ["call"]
+      "actions": ["execute"]
     },
     {
-      "name": "call-write-tool-for-notes",
-      "description": "Allow calling the write tool only for files in the user's notes directory",
+      "name": "execute-write-tool-for-notes",
+      "description": "Allow executing the write tool for files in the user's notes directory only",
       "effect": "allow",
       "principal_conditions": [],
       "resource_conditions": [
@@ -49,7 +49,7 @@
           "value": "/home/user/notes/"
         }
       ],
-      "actions": ["call"]
+      "actions": ["execute"]
     }
   ]
 }

--- a/pkgs/extensions/mcp/templates/002_agent.json
+++ b/pkgs/extensions/mcp/templates/002_agent.json
@@ -16,7 +16,7 @@
         }
       ],
       "resource_conditions": [],
-      "actions": ["list", "call", "read", "get"]
+      "actions": ["list", "execute"]
     }
   ]
 }

--- a/src/eunomia/engine/db/crud.py
+++ b/src/eunomia/engine/db/crud.py
@@ -21,7 +21,10 @@ def create_policy(policy: schemas.Policy, db: Session) -> models.Policy:
     )
     for rule in policy.rules:
         db_rule = models.Rule(
-            name=rule.name, effect=rule.effect, actions=json.dumps(rule.actions)
+            name=rule.name,
+            description=rule.description,
+            effect=rule.effect,
+            actions=json.dumps(rule.actions),
         )
 
         for condition in rule.principal_conditions:

--- a/src/eunomia/engine/db/models.py
+++ b/src/eunomia/engine/db/models.py
@@ -29,6 +29,7 @@ class Rule(db.Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str]
+    description: Mapped[Optional[str]]
     policy_id: Mapped[int] = mapped_column(ForeignKey(Policy.id))
     effect: Mapped[enums.PolicyEffect]
     actions: Mapped[list[str]] = mapped_column(JSON)

--- a/tests/eunomia_core/test_core_utils.py
+++ b/tests/eunomia_core/test_core_utils.py
@@ -1,0 +1,131 @@
+import re
+import uuid
+
+from eunomia_core.utils import generate_uri, slugify
+
+
+class TestSlugify:
+    """Test cases for the slugify function."""
+
+    def test_emoji_removal(self):
+        """Test that emojis are properly removed."""
+        assert slugify("Planetary Weather 🪐") == "planetary-weather"
+
+    def test_special_characters(self):
+        """Test that special characters are replaced with hyphens."""
+        assert slugify("some/strange?stuff") == "some-strange-stuff"
+
+    def test_leading_trailing_spaces(self):
+        """Test that leading and trailing spaces are stripped."""
+        assert slugify("  Hello World!  ") == "hello-world"
+
+    def test_mixed_separators(self):
+        """Test various separators (underscores, dots, spaces) are normalized."""
+        assert slugify("My_Awesome-Project v1.0") == "my_awesome-project-v1-0"
+
+    def test_plus_signs(self):
+        """Test that plus signs are handled correctly."""
+        assert slugify("C++ Programming Guide") == "c-programming-guide"
+
+    def test_ampersand_and_symbols(self):
+        """Test ampersands and other symbols are replaced."""
+        assert (
+            slugify("Another Test String with Spaces & Symbols!")
+            == "another-test-string-with-spaces-symbols"
+        )
+
+    def test_numbers_preserved(self):
+        """Test that numbers are preserved in the slug."""
+        assert slugify("123 ABC def") == "123-abc-def"
+
+    def test_multiple_hyphens(self):
+        """Test that multiple consecutive hyphens are collapsed and trimmed."""
+        assert slugify("---leading-and-trailing---") == "leading-and-trailing"
+
+    def test_no_special_characters(self):
+        """Test strings with no special characters are just lowercased."""
+        assert slugify("NoSpecialCharactersHere") == "nospecialcharactershere"
+
+    def test_spaces_normalization(self):
+        """Test that internal and external spaces are handled correctly."""
+        assert (
+            slugify("  leading and trailing spaces  ") == "leading-and-trailing-spaces"
+        )
+
+    def test_unicode_normalization(self):
+        """Test that accented characters are normalized to ASCII."""
+        assert slugify("München Hauptbahnhof") == "munchen-hauptbahnhof"
+
+    def test_non_ascii_removal(self):
+        """Test that non-ASCII characters that can't be normalized are removed."""
+        assert slugify("你好世界") == ""
+
+    def test_empty_string(self):
+        """Test empty string input."""
+        assert slugify("") == ""
+
+    def test_only_spaces(self):
+        """Test string with only spaces."""
+        assert slugify("   ") == ""
+
+    def test_only_special_characters(self):
+        """Test string with only special characters."""
+        assert slugify("!@#$%^&*()") == ""
+
+    def test_single_character(self):
+        """Test single character inputs."""
+        assert slugify("A") == "a"
+        assert slugify("1") == "1"
+        assert slugify("-") == ""
+
+    def test_hyphen_preservation(self):
+        """Test that existing hyphens are preserved (not duplicated)."""
+        assert slugify("already-hyphenated-string") == "already-hyphenated-string"
+
+    def test_mixed_case_with_numbers(self):
+        """Test mixed case strings with numbers."""
+        assert slugify("Version 2.1.0 BETA") == "version-2-1-0-beta"
+
+    def test_consecutive_special_chars(self):
+        """Test consecutive special characters are collapsed."""
+        assert (
+            slugify("test...multiple!!!special???chars")
+            == "test-multiple-special-chars"
+        )
+
+
+class TestGenerateUri:
+    """Test cases for the generate_uri function."""
+
+    def test_returns_string(self):
+        """Test that generate_uri returns a string."""
+        result = generate_uri()
+        assert isinstance(result, str)
+
+    def test_valid_uuid_format(self):
+        """Test that the returned string is a valid UUID format."""
+        result = generate_uri()
+        # Should match UUID4 format: 8-4-4-4-12 hex digits
+        uuid_pattern = re.compile(
+            r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        )
+        assert uuid_pattern.match(result) is not None
+
+    def test_parseable_as_uuid(self):
+        """Test that the returned string can be parsed as a UUID."""
+        result = generate_uri()
+        # Should not raise an exception
+        parsed_uuid = uuid.UUID(result)
+        assert str(parsed_uuid) == result
+
+    def test_uniqueness(self):
+        """Test that multiple calls generate different UUIDs."""
+        results = [generate_uri() for _ in range(100)]
+        # All results should be unique
+        assert len(set(results)) == 100
+
+    def test_version_4_uuid(self):
+        """Test that generated UUIDs are version 4."""
+        result = generate_uri()
+        parsed_uuid = uuid.UUID(result)
+        assert parsed_uuid.version == 4

--- a/tests/eunomia_core/test_policy_schemas.py
+++ b/tests/eunomia_core/test_policy_schemas.py
@@ -211,6 +211,22 @@ class TestRule:
         rule = Rule.model_validate(rule_data)
         assert rule.name == "allow-admin-access"
 
+    def test_invalid_name_slugification(self):
+        # Test that names that would result in empty slugs raise ValidationError
+        invalid_names = ["!!!", "---", "🚀🎉", "   "]
+
+        for invalid_name in invalid_names:
+            rule_data = {
+                "name": invalid_name,
+                "effect": PolicyEffect.ALLOW,
+                "actions": ["read"],
+            }
+            with pytest.raises(ValidationError) as exc_info:
+                Rule.model_validate(rule_data)
+
+            # Check that the error message contains the expected text
+            assert "Cannot create valid slug from:" in str(exc_info.value)
+
     def test_actions_json_parsing(self):
         # Test actions can be parsed from JSON string
         rule_data = {
@@ -346,6 +362,27 @@ class TestPolicy:
         }
         policy = Policy.model_validate(policy_data)
         assert policy.name == "my-super-complex-policy-name"
+
+    def test_invalid_name_slugification(self):
+        # Test that names that would result in empty slugs raise ValidationError
+        invalid_names = ["!!!", "---", "🚀🎉", "   "]
+
+        for invalid_name in invalid_names:
+            policy_data = {
+                "name": invalid_name,
+                "rules": [
+                    {
+                        "name": "test-rule",
+                        "effect": PolicyEffect.ALLOW,
+                        "actions": ["read"],
+                    }
+                ],
+            }
+            with pytest.raises(ValidationError) as exc_info:
+                Policy.model_validate(policy_data)
+
+            # Check that the error message contains the expected text
+            assert "Cannot create valid slug from:" in str(exc_info.value)
 
     def test_multiple_rules(self):
         # Test policy with multiple rules

--- a/tests/eunomia_core/test_policy_schemas.py
+++ b/tests/eunomia_core/test_policy_schemas.py
@@ -1,0 +1,487 @@
+import pytest
+from eunomia_core.enums.policy import ConditionOperator, PolicyEffect
+from eunomia_core.schemas.policy import (
+    Condition,
+    Policy,
+    PolicyEvaluationResult,
+    Rule,
+)
+from pydantic import ValidationError
+
+
+@pytest.fixture
+def valid_condition():
+    return {
+        "path": "attributes.role",
+        "operator": ConditionOperator.EQUALS,
+        "value": "admin",
+    }
+
+
+@pytest.fixture
+def valid_condition_with_json_value():
+    return {
+        "path": "attributes.permissions",
+        "operator": ConditionOperator.IN,
+        "value": '["read", "write"]',
+    }
+
+
+@pytest.fixture
+def valid_rule():
+    return {
+        "name": "Allow Admin Access",
+        "effect": PolicyEffect.ALLOW,
+        "actions": ["read", "write"],
+    }
+
+
+@pytest.fixture
+def valid_rule_with_conditions():
+    return {
+        "name": "Complex Rule",
+        "description": "A rule with conditions",
+        "effect": PolicyEffect.ALLOW,
+        "principal_conditions": [
+            {
+                "path": "attributes.role",
+                "operator": ConditionOperator.EQUALS,
+                "value": "admin",
+            }
+        ],
+        "resource_conditions": [
+            {
+                "path": "attributes.category",
+                "operator": ConditionOperator.IN,
+                "value": ["public", "shared"],
+            }
+        ],
+        "actions": ["read", "write", "delete"],
+    }
+
+
+@pytest.fixture
+def valid_policy():
+    return {
+        "name": "Test Policy",
+        "description": "A test policy",
+        "rules": [
+            {
+                "name": "allow-admin",
+                "effect": PolicyEffect.ALLOW,
+                "actions": ["read"],
+            }
+        ],
+    }
+
+
+class TestCondition:
+    def test_valid_cases(self, valid_condition):
+        # Basic valid condition
+        condition = Condition.model_validate(valid_condition)
+        assert condition.path == "attributes.role"
+        assert condition.operator == ConditionOperator.EQUALS
+        assert condition.value == "admin"
+
+    def test_json_value_parsing(self, valid_condition_with_json_value):
+        # Test JSON string value is parsed
+        condition = Condition.model_validate(valid_condition_with_json_value)
+        assert condition.value == ["read", "write"]
+
+    def test_non_json_string_value(self):
+        # Test non-JSON string remains as string
+        condition_data = {
+            "path": "attributes.name",
+            "operator": ConditionOperator.CONTAINS,
+            "value": "john doe",
+        }
+        condition = Condition.model_validate(condition_data)
+        assert condition.value == "john doe"
+
+    def test_numeric_value(self):
+        # Test numeric values are preserved
+        condition_data = {
+            "path": "attributes.age",
+            "operator": ConditionOperator.GREATER,
+            "value": 25,
+        }
+        condition = Condition.model_validate(condition_data)
+        assert condition.value == 25
+
+    def test_boolean_value(self):
+        # Test boolean values are preserved
+        condition_data = {
+            "path": "attributes.active",
+            "operator": ConditionOperator.EQUALS,
+            "value": True,
+        }
+        condition = Condition.model_validate(condition_data)
+        assert condition.value is True
+
+    def test_list_value(self):
+        # Test list values are preserved
+        condition_data = {
+            "path": "attributes.roles",
+            "operator": ConditionOperator.IN,
+            "value": ["admin", "user"],
+        }
+        condition = Condition.model_validate(condition_data)
+        assert condition.value == ["admin", "user"]
+
+    def test_all_operators(self):
+        # Test all valid operators
+        operators = [
+            ConditionOperator.EQUALS,
+            ConditionOperator.NOT_EQUALS,
+            ConditionOperator.CONTAINS,
+            ConditionOperator.NOT_CONTAINS,
+            ConditionOperator.STARTS_WITH,
+            ConditionOperator.ENDS_WITH,
+            ConditionOperator.GREATER,
+            ConditionOperator.GREATER_OR_EQUAL,
+            ConditionOperator.LESS,
+            ConditionOperator.LESS_OR_EQUAL,
+            ConditionOperator.IN,
+            ConditionOperator.NOT_IN,
+        ]
+
+        for operator in operators:
+            condition_data = {
+                "path": "test.path",
+                "operator": operator,
+                "value": "test_value",
+            }
+            condition = Condition.model_validate(condition_data)
+            assert condition.operator == operator
+
+    def test_invalid_cases(self):
+        # Missing required fields
+        with pytest.raises(ValidationError):
+            Condition.model_validate(
+                {"path": "test.path", "operator": ConditionOperator.EQUALS}
+            )
+
+        with pytest.raises(ValidationError):
+            Condition.model_validate({"path": "test.path", "value": "test"})
+
+        with pytest.raises(ValidationError):
+            Condition.model_validate(
+                {"operator": ConditionOperator.EQUALS, "value": "test"}
+            )
+
+        # Invalid operator
+        with pytest.raises(ValidationError):
+            Condition.model_validate(
+                {
+                    "path": "test.path",
+                    "operator": "invalid_operator",
+                    "value": "test",
+                }
+            )
+
+
+class TestRule:
+    def test_valid_cases(self, valid_rule):
+        # Basic valid rule
+        rule = Rule.model_validate(valid_rule)
+        assert rule.name == "allow-admin-access"  # Should be slugified
+        assert rule.effect == PolicyEffect.ALLOW
+        assert rule.actions == ["read", "write"]
+        assert rule.description is None
+        assert rule.principal_conditions == []
+        assert rule.resource_conditions == []
+
+    def test_rule_with_conditions(self, valid_rule_with_conditions):
+        # Rule with all fields
+        rule = Rule.model_validate(valid_rule_with_conditions)
+        assert rule.name == "complex-rule"  # Should be slugified
+        assert rule.description == "A rule with conditions"
+        assert rule.effect == PolicyEffect.ALLOW
+        assert len(rule.principal_conditions) == 1
+        assert len(rule.resource_conditions) == 1
+        assert rule.actions == ["read", "write", "delete"]
+
+    def test_name_slugification(self):
+        # Test name is properly slugified
+        rule_data = {
+            "name": "Allow Admin Access!!!",
+            "effect": PolicyEffect.ALLOW,
+            "actions": ["read"],
+        }
+        rule = Rule.model_validate(rule_data)
+        assert rule.name == "allow-admin-access"
+
+    def test_actions_json_parsing(self):
+        # Test actions can be parsed from JSON string
+        rule_data = {
+            "name": "test-rule",
+            "effect": PolicyEffect.ALLOW,
+            "actions": '["read", "write", "delete"]',
+        }
+        rule = Rule.model_validate(rule_data)
+        assert rule.actions == ["read", "write", "delete"]
+
+    def test_actions_list_preserved(self):
+        # Test actions list is preserved when already a list
+        rule_data = {
+            "name": "test-rule",
+            "effect": PolicyEffect.ALLOW,
+            "actions": ["read", "write"],
+        }
+        rule = Rule.model_validate(rule_data)
+        assert rule.actions == ["read", "write"]
+
+    def test_both_effects(self):
+        # Test both ALLOW and DENY effects
+        for effect in [PolicyEffect.ALLOW, PolicyEffect.DENY]:
+            rule_data = {
+                "name": "test-rule",
+                "effect": effect,
+                "actions": ["read"],
+            }
+            rule = Rule.model_validate(rule_data)
+            assert rule.effect == effect
+
+    def test_invalid_cases(self):
+        # Missing required fields
+        with pytest.raises(ValidationError):
+            Rule.model_validate({"name": "test", "effect": PolicyEffect.ALLOW})
+
+        with pytest.raises(ValidationError):
+            Rule.model_validate({"name": "test", "actions": ["read"]})
+
+        with pytest.raises(ValidationError):
+            Rule.model_validate({"effect": PolicyEffect.ALLOW, "actions": ["read"]})
+
+        # Invalid effect
+        with pytest.raises(ValidationError):
+            Rule.model_validate(
+                {
+                    "name": "test",
+                    "effect": "invalid_effect",
+                    "actions": ["read"],
+                }
+            )
+
+        # Invalid actions JSON
+        with pytest.raises(ValidationError):
+            Rule.model_validate(
+                {
+                    "name": "test",
+                    "effect": PolicyEffect.ALLOW,
+                    "actions": "invalid_json[",
+                }
+            )
+
+        # Extra fields not allowed
+        with pytest.raises(ValidationError):
+            Rule.model_validate(
+                {
+                    "name": "test",
+                    "effect": PolicyEffect.ALLOW,
+                    "actions": ["read"],
+                    "extra_field": "not_allowed",
+                }
+            )
+
+
+class TestPolicy:
+    def test_valid_cases(self, valid_policy):
+        # Basic valid policy
+        policy = Policy.model_validate(valid_policy)
+        assert policy.name == "test-policy"  # Should be slugified
+        assert policy.description == "A test policy"
+        assert policy.version == "1.0"  # Default value
+        assert policy.default_effect == PolicyEffect.DENY  # Default value
+        assert len(policy.rules) == 1
+
+    def test_default_values(self):
+        # Test default values are applied
+        policy_data = {
+            "name": "Minimal Policy",
+            "rules": [
+                {
+                    "name": "test-rule",
+                    "effect": PolicyEffect.ALLOW,
+                    "actions": ["read"],
+                }
+            ],
+        }
+        policy = Policy.model_validate(policy_data)
+        assert policy.version == "1.0"
+        assert policy.default_effect == PolicyEffect.DENY
+        assert policy.description is None
+
+    def test_custom_values(self):
+        # Test custom values override defaults
+        policy_data = {
+            "version": "2.0",
+            "name": "Custom Policy",
+            "description": "Custom description",
+            "default_effect": PolicyEffect.ALLOW,
+            "rules": [
+                {
+                    "name": "test-rule",
+                    "effect": PolicyEffect.ALLOW,
+                    "actions": ["read"],
+                }
+            ],
+        }
+        policy = Policy.model_validate(policy_data)
+        assert policy.version == "2.0"
+        assert policy.default_effect == PolicyEffect.ALLOW
+        assert policy.description == "Custom description"
+
+    def test_name_slugification(self):
+        # Test name is properly slugified
+        policy_data = {
+            "name": "My Super Complex Policy Name!!!",
+            "rules": [
+                {
+                    "name": "test-rule",
+                    "effect": PolicyEffect.ALLOW,
+                    "actions": ["read"],
+                }
+            ],
+        }
+        policy = Policy.model_validate(policy_data)
+        assert policy.name == "my-super-complex-policy-name"
+
+    def test_multiple_rules(self):
+        # Test policy with multiple rules
+        policy_data = {
+            "name": "Multi Rule Policy",
+            "rules": [
+                {
+                    "name": "allow-rule",
+                    "effect": PolicyEffect.ALLOW,
+                    "actions": ["read"],
+                },
+                {
+                    "name": "deny-rule",
+                    "effect": PolicyEffect.DENY,
+                    "actions": ["write", "delete"],
+                },
+            ],
+        }
+        policy = Policy.model_validate(policy_data)
+        assert len(policy.rules) == 2
+        assert policy.rules[0].name == "allow-rule"
+        assert policy.rules[1].name == "deny-rule"
+
+    def test_invalid_cases(self):
+        # Missing required fields
+        with pytest.raises(ValidationError):
+            Policy.model_validate({"name": "test"})
+
+        with pytest.raises(ValidationError):
+            Policy.model_validate({"rules": []})
+
+        # Invalid default_effect
+        with pytest.raises(ValidationError):
+            Policy.model_validate(
+                {
+                    "name": "test",
+                    "default_effect": "invalid_effect",
+                    "rules": [
+                        {
+                            "name": "test-rule",
+                            "effect": PolicyEffect.ALLOW,
+                            "actions": ["read"],
+                        }
+                    ],
+                }
+            )
+
+        # Extra fields not allowed
+        with pytest.raises(ValidationError):
+            Policy.model_validate(
+                {
+                    "name": "test",
+                    "rules": [
+                        {
+                            "name": "test-rule",
+                            "effect": PolicyEffect.ALLOW,
+                            "actions": ["read"],
+                        }
+                    ],
+                    "extra_field": "not_allowed",
+                }
+            )
+
+    def test_empty_rules_allowed(self):
+        # Empty rules list should be allowed
+        policy_data = {
+            "name": "Empty Policy",
+            "rules": [],
+        }
+        policy = Policy.model_validate(policy_data)
+        assert policy.name == "empty-policy"
+        assert policy.rules == []
+        assert policy.default_effect == PolicyEffect.DENY
+
+
+class TestPolicyEvaluationResult:
+    def test_valid_cases(self):
+        # Valid result with matched rule
+        rule = Rule(
+            name="test-rule",
+            effect=PolicyEffect.ALLOW,
+            actions=["read"],
+        )
+        result_data = {
+            "effect": PolicyEffect.ALLOW,
+            "matched_rule": rule,
+            "policy_name": "test-policy",
+        }
+        result = PolicyEvaluationResult.model_validate(result_data)
+        assert result.effect == PolicyEffect.ALLOW
+        assert result.matched_rule == rule
+        assert result.policy_name == "test-policy"
+
+    def test_no_matched_rule(self):
+        # Valid result without matched rule (default effect)
+        result_data = {
+            "effect": PolicyEffect.DENY,
+            "matched_rule": None,
+            "policy_name": "test-policy",
+        }
+        result = PolicyEvaluationResult.model_validate(result_data)
+        assert result.effect == PolicyEffect.DENY
+        assert result.matched_rule is None
+        assert result.policy_name == "test-policy"
+
+    def test_both_effects(self):
+        # Test both ALLOW and DENY effects
+        for effect in [PolicyEffect.ALLOW, PolicyEffect.DENY]:
+            result_data = {
+                "effect": effect,
+                "policy_name": "test-policy",
+            }
+            result = PolicyEvaluationResult.model_validate(result_data)
+            assert result.effect == effect
+
+    def test_invalid_cases(self):
+        # Missing required fields
+        with pytest.raises(ValidationError):
+            PolicyEvaluationResult.model_validate(
+                {
+                    "effect": PolicyEffect.ALLOW,
+                }
+            )
+
+        with pytest.raises(ValidationError):
+            PolicyEvaluationResult.model_validate(
+                {
+                    "policy_name": "test-policy",
+                }
+            )
+
+        # Invalid effect
+        with pytest.raises(ValidationError):
+            PolicyEvaluationResult.model_validate(
+                {
+                    "effect": "invalid_effect",
+                    "policy_name": "test-policy",
+                }
+            )

--- a/tests/eunomia_mcp/conftest.py
+++ b/tests/eunomia_mcp/conftest.py
@@ -1,0 +1,50 @@
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from eunomia_mcp.cli.utils import DEFAULT_POLICY
+from eunomia_sdk.client import EunomiaClient
+from typer.testing import CliRunner
+
+
+@pytest.fixture
+def runner():
+    """Create CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def temp_dir():
+    """Create temporary directory for tests."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def sample_policy_file(temp_dir):
+    """Create a sample policy file for testing."""
+    policy_file = temp_dir / "test_policy.json"
+    with open(policy_file, "w") as f:
+        json.dump(DEFAULT_POLICY.model_dump(exclude_none=True), f, indent=2)
+    return policy_file
+
+
+@pytest.fixture
+def invalid_policy_file(temp_dir):
+    """Create an invalid policy file for testing."""
+    policy_file = temp_dir / "invalid_policy.json"
+    with open(policy_file, "w") as f:
+        json.dump({"invalid": "policy"}, f, indent=2)
+    return policy_file
+
+
+@pytest.fixture
+def mock_eunomia_client():
+    """Create mock Eunomia client."""
+    client = Mock(spec=EunomiaClient)
+    client.get_policies.return_value = []
+    client.delete_policy.return_value = None
+    client.create_policy.return_value = None
+    return client

--- a/tests/eunomia_mcp/test_cli_main.py
+++ b/tests/eunomia_mcp/test_cli_main.py
@@ -1,63 +1,15 @@
 import json
 import os
-import tempfile
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, patch
 
-import pytest
 from eunomia_core import enums, schemas
 from eunomia_mcp.cli.main import app
-from eunomia_mcp.cli.utils import (
-    DEFAULT_POLICY,
-    SAMPLE_SERVER_CODE,
-    load_policy_config,
-    push_policy_config,
-)
-from eunomia_sdk.client import EunomiaClient
-from typer.testing import CliRunner
+from eunomia_mcp.cli.utils import DEFAULT_POLICY, SAMPLE_SERVER_CODE
+from fastmcp import FastMCP
 
 
-class TestEunomiaCLI:
-    """Test suite for Eunomia MCP CLI commands."""
-
-    @pytest.fixture
-    def runner(self):
-        """Create CLI test runner."""
-        return CliRunner()
-
-    @pytest.fixture
-    def temp_dir(self):
-        """Create temporary directory for tests."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            yield Path(tmpdir)
-
-    @pytest.fixture
-    def sample_policy_file(self, temp_dir):
-        """Create a sample policy file for testing."""
-        policy_file = temp_dir / "test_policy.json"
-        with open(policy_file, "w") as f:
-            json.dump(DEFAULT_POLICY.model_dump(exclude_none=True), f, indent=2)
-        return policy_file
-
-    @pytest.fixture
-    def invalid_policy_file(self, temp_dir):
-        """Create an invalid policy file for testing."""
-        policy_file = temp_dir / "invalid_policy.json"
-        with open(policy_file, "w") as f:
-            json.dump({"invalid": "policy"}, f, indent=2)
-        return policy_file
-
-    @pytest.fixture
-    def mock_eunomia_client(self):
-        """Create mock Eunomia client."""
-        client = Mock(spec=EunomiaClient)
-        client.get_policies.return_value = []
-        client.delete_policy.return_value = None
-        client.create_policy.return_value = None
-        return client
-
-
-class TestInitCommand(TestEunomiaCLI):
+class TestInitCommand:
     """Test the init command."""
 
     def test_init_default_policy_file(self, runner, temp_dir):
@@ -152,8 +104,125 @@ class TestInitCommand(TestEunomiaCLI):
         assert "Push the policy configuration file to Eunomia" in result.stdout
         assert "Run your MCP server with authorization" in result.stdout
 
+    @patch("eunomia_mcp.cli.main.load_mcp_instance")
+    @patch(
+        "eunomia_mcp.cli.main.generate_custom_policy_from_mcp", new_callable=AsyncMock
+    )
+    def test_init_with_custom_mcp_success(
+        self, mock_generate_policy, mock_load_mcp, runner, temp_dir
+    ):
+        """Test init command with successful custom MCP policy generation."""
+        os.chdir(temp_dir)
 
-class TestValidateCommand(TestEunomiaCLI):
+        # Create real FastMCP instance
+        mcp = FastMCP("test-mcp-server")
+
+        @mcp.tool()
+        def add(a: int, b: int) -> int:
+            """Add two numbers"""
+            return a + b
+
+        mock_load_mcp.return_value = mcp
+
+        # Mock generated policy
+        custom_policy = schemas.Policy(
+            version="1.0",
+            name="test-custom-policy",
+            description="Custom policy for test server",
+            default_effect=enums.PolicyEffect.DENY,
+            rules=[],
+        )
+
+        mock_generate_policy.return_value = custom_policy
+
+        result = runner.invoke(app, ["init", "--custom-mcp", "test.module:mcp"])
+
+        assert result.exit_code == 0
+        assert (
+            "Generated custom policy from MCP server: test-mcp-server" in result.stdout
+        )
+        assert "Generated policy configuration file: mcp_policies.json" in result.stdout
+
+        mock_load_mcp.assert_called_once_with("test.module:mcp")
+
+        # Verify the policy file contains the custom policy
+        with open("mcp_policies.json") as f:
+            policy_data = json.load(f)
+        assert policy_data["name"] == "test-custom-policy"
+
+    @patch("eunomia_mcp.cli.main.load_mcp_instance")
+    def test_init_with_custom_mcp_load_error(self, mock_load_mcp, runner, temp_dir):
+        """Test init command with MCP loading error."""
+        os.chdir(temp_dir)
+        mock_load_mcp.side_effect = ImportError("Cannot import module: test.module")
+
+        result = runner.invoke(app, ["init", "--custom-mcp", "test.module:mcp"])
+
+        assert result.exit_code == 1
+        assert (
+            "Error generating custom policy: Cannot import module: test.module"
+            in result.stdout
+        )
+        mock_load_mcp.assert_called_once_with("test.module:mcp")
+
+    @patch("eunomia_mcp.cli.main.load_mcp_instance")
+    @patch(
+        "eunomia_mcp.cli.main.generate_custom_policy_from_mcp", new_callable=AsyncMock
+    )
+    def test_init_with_custom_mcp_policy_generation_error(
+        self, mock_generate_policy, mock_load_mcp, runner, temp_dir
+    ):
+        """Test init command with policy generation error."""
+        os.chdir(temp_dir)
+
+        mcp = FastMCP("test-server")
+        mock_load_mcp.return_value = mcp
+
+        mock_generate_policy.side_effect = Exception("Policy generation failed")
+
+        result = runner.invoke(app, ["init", "--custom-mcp", "test.module:mcp"])
+
+        assert result.exit_code == 1
+        assert (
+            "Error generating custom policy: Policy generation failed" in result.stdout
+        )
+
+    @patch("eunomia_mcp.cli.main.load_mcp_instance")
+    @patch(
+        "eunomia_mcp.cli.main.generate_custom_policy_from_mcp", new_callable=AsyncMock
+    )
+    def test_init_with_custom_mcp_and_sample(
+        self, mock_generate_policy, mock_load_mcp, runner, temp_dir
+    ):
+        """Test init command with custom MCP and sample server generation."""
+        os.chdir(temp_dir)
+
+        mcp = FastMCP("test-server")
+
+        @mcp.tool()
+        def multiply(x: int, y: int) -> int:
+            """Multiply two numbers"""
+            return x * y
+
+        mock_load_mcp.return_value = mcp
+
+        custom_policy = DEFAULT_POLICY.model_copy()
+        custom_policy.name = "custom-test-policy"
+
+        mock_generate_policy.return_value = custom_policy
+
+        result = runner.invoke(
+            app, ["init", "--custom-mcp", "test.module:mcp", "--sample"]
+        )
+
+        assert result.exit_code == 0
+        assert "Generated custom policy from MCP server: test-server" in result.stdout
+        assert "Generated sample server: mcp_server.py" in result.stdout
+        assert Path("mcp_policies.json").exists()
+        assert Path("mcp_server.py").exists()
+
+
+class TestValidateCommand:
     """Test the validate command."""
 
     def test_validate_valid_policy(self, runner, sample_policy_file):
@@ -189,7 +258,7 @@ class TestValidateCommand(TestEunomiaCLI):
         assert "Error validating policy:" in result.stdout
 
 
-class TestPushCommand(TestEunomiaCLI):
+class TestPushCommand:
     """Test the push command."""
 
     @patch("eunomia_mcp.cli.main.EunomiaClient")
@@ -294,121 +363,8 @@ class TestPushCommand(TestEunomiaCLI):
         assert "Error pushing policy:" in result.stdout
 
 
-class TestCLIUtils:
-    """Test CLI utility functions."""
-
-    @pytest.fixture
-    def temp_dir(self):
-        """Create temporary directory for tests."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            yield Path(tmpdir)
-
-    @pytest.fixture
-    def sample_policy_file(self, temp_dir):
-        """Create a sample policy file for testing."""
-        policy_file = temp_dir / "test_policy.json"
-        with open(policy_file, "w") as f:
-            json.dump(DEFAULT_POLICY.model_dump(exclude_none=True), f, indent=2)
-        return policy_file
-
-    @pytest.fixture
-    def mock_eunomia_client(self):
-        """Create mock Eunomia client."""
-        client = Mock(spec=EunomiaClient)
-        client.get_policies.return_value = []
-        client.delete_policy.return_value = None
-        client.create_policy.return_value = None
-        return client
-
-    def test_load_policy_config_success(self, sample_policy_file):
-        """Test successful policy loading."""
-        policy = load_policy_config(str(sample_policy_file))
-
-        assert isinstance(policy, schemas.Policy)
-        assert policy.name == "mcp-default-policy"
-        assert policy.version == "1.0"
-        assert policy.default_effect == enums.PolicyEffect.DENY
-        assert len(policy.rules) == len(DEFAULT_POLICY.rules)
-
-    def test_load_policy_config_file_not_found(self):
-        """Test policy loading with nonexistent file."""
-        with pytest.raises(FileNotFoundError) as exc_info:
-            load_policy_config("nonexistent.json")
-
-        assert "Policy file not found: nonexistent.json" in str(exc_info.value)
-
-    def test_load_policy_config_invalid_json(self, temp_dir):
-        """Test policy loading with invalid JSON."""
-        policy_file = temp_dir / "invalid.json"
-        policy_file.write_text('{"invalid": json}')
-
-        with pytest.raises(Exception):
-            load_policy_config(str(policy_file))
-
-    def test_load_policy_config_invalid_schema(self, temp_dir):
-        """Test policy loading with invalid policy schema."""
-        policy_file = temp_dir / "invalid_schema.json"
-        policy_file.write_text('{"invalid": "schema"}')
-
-        with pytest.raises(Exception):
-            load_policy_config(str(policy_file))
-
-    def test_push_policy_config_success(self, sample_policy_file, mock_eunomia_client):
-        """Test successful policy push."""
-        push_policy_config(str(sample_policy_file), False, mock_eunomia_client)
-
-        mock_eunomia_client.create_policy.assert_called_once()
-        mock_eunomia_client.get_policies.assert_not_called()
-        mock_eunomia_client.delete_policy.assert_not_called()
-
-    def test_push_policy_config_with_overwrite(
-        self, sample_policy_file, mock_eunomia_client
-    ):
-        """Test policy push with overwrite."""
-        existing_policy = Mock()
-        existing_policy.name = "existing-policy"
-        mock_eunomia_client.get_policies.return_value = [existing_policy]
-
-        push_policy_config(str(sample_policy_file), True, mock_eunomia_client)
-
-        mock_eunomia_client.get_policies.assert_called_once()
-        mock_eunomia_client.delete_policy.assert_called_once_with("existing-policy")
-        mock_eunomia_client.create_policy.assert_called_once()
-
-    def test_push_policy_config_multiple_existing_policies(
-        self, sample_policy_file, mock_eunomia_client
-    ):
-        """Test policy push with multiple existing policies to overwrite."""
-        existing_policies = [Mock(name="policy1"), Mock(name="policy2")]
-        existing_policies[0].name = "policy1"
-        existing_policies[1].name = "policy2"
-        mock_eunomia_client.get_policies.return_value = existing_policies
-
-        push_policy_config(str(sample_policy_file), True, mock_eunomia_client)
-
-        mock_eunomia_client.get_policies.assert_called_once()
-        assert mock_eunomia_client.delete_policy.call_count == 2
-        mock_eunomia_client.delete_policy.assert_any_call("policy1")
-        mock_eunomia_client.delete_policy.assert_any_call("policy2")
-        mock_eunomia_client.create_policy.assert_called_once()
-
-    def test_push_policy_config_client_error(
-        self, sample_policy_file, mock_eunomia_client
-    ):
-        """Test policy push with client error."""
-        mock_eunomia_client.create_policy.side_effect = Exception("API Error")
-
-        with pytest.raises(Exception, match="API Error"):
-            push_policy_config(str(sample_policy_file), False, mock_eunomia_client)
-
-
 class TestCLIIntegration:
     """Integration tests for CLI commands."""
-
-    @pytest.fixture
-    def runner(self):
-        """Create CLI test runner."""
-        return CliRunner()
 
     def test_cli_help(self, runner):
         """Test CLI help output."""
@@ -449,29 +405,3 @@ class TestCLIIntegration:
 
         assert result.exit_code == 0
         assert "Eunomia MCP Authorization Middleware CLI" in result.stdout
-
-
-class TestConstants:
-    """Test CLI constants and defaults."""
-
-    def test_default_policy_structure(self):
-        """Test that DEFAULT_POLICY has correct structure."""
-        assert DEFAULT_POLICY.version == "1.0"
-        assert DEFAULT_POLICY.name == "mcp-default-policy"
-        assert DEFAULT_POLICY.default_effect == enums.PolicyEffect.DENY
-        assert len(DEFAULT_POLICY.rules) == 1
-
-        # Check rule
-        listing_rule = DEFAULT_POLICY.rules[0]
-        assert listing_rule.name == "unrestricted-access"
-        assert listing_rule.effect == enums.PolicyEffect.ALLOW
-        assert listing_rule.actions == ["list", "execute"]
-
-    def test_sample_server_code_structure(self):
-        """Test that SAMPLE_SERVER_CODE contains expected components."""
-        assert "from fastmcp import FastMCP" in SAMPLE_SERVER_CODE
-        assert "from eunomia_mcp import EunomiaMcpMiddleware" in SAMPLE_SERVER_CODE
-        assert "EunomiaMcpMiddleware()" in SAMPLE_SERVER_CODE
-        assert "@mcp.tool()" in SAMPLE_SERVER_CODE
-        assert "def add(a: int, b: int) -> int:" in SAMPLE_SERVER_CODE
-        assert "mcp.run" in SAMPLE_SERVER_CODE

--- a/tests/eunomia_mcp/test_cli_utils.py
+++ b/tests/eunomia_mcp/test_cli_utils.py
@@ -1,0 +1,513 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from eunomia_core import enums, schemas
+from eunomia_mcp.cli.utils import (
+    DEFAULT_POLICY,
+    SAMPLE_SERVER_CODE,
+    generate_custom_policy_from_mcp,
+    load_mcp_instance,
+    load_policy_config,
+    push_policy_config,
+)
+from fastmcp import FastMCP
+
+
+class TestCLIUtils:
+    """Test CLI utility functions."""
+
+    def test_load_policy_config_success(self, sample_policy_file):
+        """Test successful policy loading."""
+        policy = load_policy_config(str(sample_policy_file))
+
+        assert isinstance(policy, schemas.Policy)
+        assert policy.name == "mcp-default-policy"
+        assert policy.version == "1.0"
+        assert policy.default_effect == enums.PolicyEffect.DENY
+        assert len(policy.rules) == len(DEFAULT_POLICY.rules)
+
+    def test_load_policy_config_file_not_found(self):
+        """Test policy loading with nonexistent file."""
+        with pytest.raises(FileNotFoundError) as exc_info:
+            load_policy_config("nonexistent.json")
+
+        assert "Policy file not found: nonexistent.json" in str(exc_info.value)
+
+    def test_load_policy_config_invalid_json(self, temp_dir):
+        """Test policy loading with invalid JSON."""
+        policy_file = temp_dir / "invalid.json"
+        policy_file.write_text('{"invalid": json}')
+
+        with pytest.raises(Exception):
+            load_policy_config(str(policy_file))
+
+    def test_load_policy_config_invalid_schema(self, temp_dir):
+        """Test policy loading with invalid policy schema."""
+        policy_file = temp_dir / "invalid_schema.json"
+        policy_file.write_text('{"invalid": "schema"}')
+
+        with pytest.raises(Exception):
+            load_policy_config(str(policy_file))
+
+    def test_push_policy_config_success(self, sample_policy_file, mock_eunomia_client):
+        """Test successful policy push."""
+        push_policy_config(str(sample_policy_file), False, mock_eunomia_client)
+
+        mock_eunomia_client.create_policy.assert_called_once()
+        mock_eunomia_client.get_policies.assert_not_called()
+        mock_eunomia_client.delete_policy.assert_not_called()
+
+    def test_push_policy_config_with_overwrite(
+        self, sample_policy_file, mock_eunomia_client
+    ):
+        """Test policy push with overwrite."""
+        existing_policy = Mock()
+        existing_policy.name = "existing-policy"
+        mock_eunomia_client.get_policies.return_value = [existing_policy]
+
+        push_policy_config(str(sample_policy_file), True, mock_eunomia_client)
+
+        mock_eunomia_client.get_policies.assert_called_once()
+        mock_eunomia_client.delete_policy.assert_called_once_with("existing-policy")
+        mock_eunomia_client.create_policy.assert_called_once()
+
+    def test_push_policy_config_multiple_existing_policies(
+        self, sample_policy_file, mock_eunomia_client
+    ):
+        """Test policy push with multiple existing policies to overwrite."""
+        existing_policies = [Mock(name="policy1"), Mock(name="policy2")]
+        existing_policies[0].name = "policy1"
+        existing_policies[1].name = "policy2"
+        mock_eunomia_client.get_policies.return_value = existing_policies
+
+        push_policy_config(str(sample_policy_file), True, mock_eunomia_client)
+
+        mock_eunomia_client.get_policies.assert_called_once()
+        assert mock_eunomia_client.delete_policy.call_count == 2
+        mock_eunomia_client.delete_policy.assert_any_call("policy1")
+        mock_eunomia_client.delete_policy.assert_any_call("policy2")
+        mock_eunomia_client.create_policy.assert_called_once()
+
+    def test_push_policy_config_client_error(
+        self, sample_policy_file, mock_eunomia_client
+    ):
+        """Test policy push with client error."""
+        mock_eunomia_client.create_policy.side_effect = Exception("API Error")
+
+        with pytest.raises(Exception, match="API Error"):
+            push_policy_config(str(sample_policy_file), False, mock_eunomia_client)
+
+
+class TestConstants:
+    """Test CLI constants and defaults."""
+
+    def test_default_policy_structure(self):
+        """Test that DEFAULT_POLICY has correct structure."""
+        assert DEFAULT_POLICY.version == "1.0"
+        assert DEFAULT_POLICY.name == "mcp-default-policy"
+        assert DEFAULT_POLICY.default_effect == enums.PolicyEffect.DENY
+        assert len(DEFAULT_POLICY.rules) == 1
+
+        # Check rule
+        listing_rule = DEFAULT_POLICY.rules[0]
+        assert listing_rule.name == "unrestricted-access"
+        assert listing_rule.effect == enums.PolicyEffect.ALLOW
+        assert listing_rule.actions == ["list", "execute"]
+
+    def test_sample_server_code_structure(self):
+        """Test that SAMPLE_SERVER_CODE contains expected components."""
+        assert "from fastmcp import FastMCP" in SAMPLE_SERVER_CODE
+        assert "from eunomia_mcp import EunomiaMcpMiddleware" in SAMPLE_SERVER_CODE
+        assert "EunomiaMcpMiddleware()" in SAMPLE_SERVER_CODE
+        assert "@mcp.tool()" in SAMPLE_SERVER_CODE
+        assert "def add(a: int, b: int) -> int:" in SAMPLE_SERVER_CODE
+        assert "mcp.run" in SAMPLE_SERVER_CODE
+
+
+class TestLoadMcpInstance:
+    """Test the load_mcp_instance function."""
+
+    @patch("eunomia_mcp.cli.utils.importlib.import_module")
+    def test_load_mcp_instance_success_module_import(self, mock_import_module):
+        """Test successful MCP instance loading via module import."""
+        # Create real FastMCP instance
+        mcp = FastMCP("test-server")
+
+        @mcp.tool()
+        def test_tool() -> str:
+            """A test tool"""
+            return "test"
+
+        # Create a simple mock module without any async attributes
+        mock_module = type("MockModule", (), {})()
+        mock_module.mcp = mcp
+        mock_import_module.return_value = mock_module
+
+        result = load_mcp_instance("test.module:mcp")
+
+        assert result == mcp
+        assert isinstance(result, FastMCP)
+        mock_import_module.assert_called_once_with("test.module")
+
+    @patch("eunomia_mcp.cli.utils.importlib.import_module")
+    @patch("eunomia_mcp.cli.utils.os.path.exists")
+    @patch("eunomia_mcp.cli.utils.importlib.util.spec_from_file_location")
+    @patch("eunomia_mcp.cli.utils.importlib.util.module_from_spec")
+    def test_load_mcp_instance_success_file_import(
+        self,
+        mock_module_from_spec,
+        mock_spec_from_file,
+        mock_exists,
+        mock_import_module,
+    ):
+        """Test successful MCP instance loading via file import."""
+        # Mock import_module to fail initially
+        mock_import_module.side_effect = ImportError("No module named 'test.file'")
+
+        # Mock file exists
+        mock_exists.return_value = True
+
+        # Mock spec creation and module loading
+        mock_spec = Mock()
+        mock_loader = Mock()
+        mock_spec.loader = mock_loader
+        mock_spec_from_file.return_value = mock_spec
+
+        # Create real FastMCP instance
+        mcp = FastMCP("file-server")
+
+        @mcp.resource("uri://test")
+        def test_resource() -> str:
+            """A test resource"""
+            return "test resource"
+
+        # Use a simple mock module without any async attributes
+        mock_module = type("MockModule", (), {})()
+        mock_module.mcp = mcp
+        mock_module_from_spec.return_value = mock_module
+
+        result = load_mcp_instance("test/file:mcp")
+
+        assert result == mcp
+        assert isinstance(result, FastMCP)
+        mock_import_module.assert_called_once_with("test/file")
+        mock_exists.assert_called_once_with("test/file.py")
+        mock_spec_from_file.assert_called_once_with("custom_mcp", "test/file.py")
+        mock_loader.exec_module.assert_called_once_with(mock_module)
+
+    @patch("eunomia_mcp.cli.utils.importlib.import_module")
+    @patch("eunomia_mcp.cli.utils.os.path.exists")
+    @patch("eunomia_mcp.cli.utils.importlib.util.spec_from_file_location")
+    @patch("eunomia_mcp.cli.utils.importlib.util.module_from_spec")
+    def test_load_mcp_instance_success_file_import_with_py_extension(
+        self,
+        mock_module_from_spec,
+        mock_spec_from_file,
+        mock_exists,
+        mock_import_module,
+    ):
+        """Test successful MCP instance loading with .py extension."""
+        mock_import_module.side_effect = ImportError("No module named 'test.file.py'")
+        mock_exists.return_value = True
+
+        mock_spec = Mock()
+        mock_loader = Mock()
+        mock_spec.loader = mock_loader
+        mock_spec_from_file.return_value = mock_spec
+
+        # Create real FastMCP instance
+        mcp = FastMCP("py-server")
+
+        @mcp.prompt("test-prompt")
+        def test_prompt() -> str:
+            """A test prompt"""
+            return "test prompt"
+
+        # Use a simple mock module without any async attributes
+        mock_module = type("MockModule", (), {})()
+        mock_module.server_instance = mcp
+        mock_module_from_spec.return_value = mock_module
+
+        result = load_mcp_instance("test/file.py:server_instance")
+
+        assert result == mcp
+        assert isinstance(result, FastMCP)
+        mock_spec_from_file.assert_called_once_with("custom_mcp", "test/file.py")
+
+    def test_load_mcp_instance_invalid_path_format(self):
+        """Test load_mcp_instance with invalid path format."""
+        with pytest.raises(ValueError) as exc_info:
+            load_mcp_instance("invalid_path_without_colon")
+
+        assert "Invalid MCP path format" in str(exc_info.value)
+        assert "Expected format: 'module.path:variable_name'" in str(exc_info.value)
+
+    @patch("eunomia_mcp.cli.utils.importlib.import_module")
+    @patch("eunomia_mcp.cli.utils.os.path.exists")
+    def test_load_mcp_instance_import_error_no_file(
+        self, mock_exists, mock_import_module
+    ):
+        """Test load_mcp_instance with import error and no file fallback."""
+        mock_import_module.side_effect = ImportError("No module named 'nonexistent'")
+        mock_exists.return_value = False
+
+        with pytest.raises(ImportError) as exc_info:
+            load_mcp_instance("nonexistent.module:mcp")
+
+        assert "Cannot import module: nonexistent.module" in str(exc_info.value)
+
+    @patch("eunomia_mcp.cli.utils.importlib.import_module")
+    def test_load_mcp_instance_variable_not_found(self, mock_import_module):
+        """Test load_mcp_instance with missing variable in module."""
+        # Create a simple mock module without any async attributes
+        mock_module = type("MockModule", (), {})()
+        mock_import_module.return_value = mock_module
+
+        with pytest.raises(ValueError) as exc_info:
+            load_mcp_instance("test.module:nonexistent_var")
+
+        assert "Variable 'nonexistent_var' not found in module 'test.module'" in str(
+            exc_info.value
+        )
+
+    @patch("eunomia_mcp.cli.utils.importlib.import_module")
+    def test_load_mcp_instance_not_fastmcp_instance(self, mock_import_module):
+        """Test load_mcp_instance with object that's not a FastMCP instance."""
+        # Create a simple mock module without any async attributes
+        mock_module = type("MockModule", (), {})()
+        mock_module.not_mcp = "not an MCP instance"
+        mock_import_module.return_value = mock_module
+
+        with pytest.raises(TypeError) as exc_info:
+            load_mcp_instance("test.module:not_mcp")
+
+        assert "Object at test.module:not_mcp is not a FastMCP instance" in str(
+            exc_info.value
+        )
+        assert "Got str" in str(exc_info.value)
+
+    @patch("eunomia_mcp.cli.utils.importlib.import_module")
+    @patch("eunomia_mcp.cli.utils.os.path.exists")
+    @patch("eunomia_mcp.cli.utils.importlib.util.spec_from_file_location")
+    def test_load_mcp_instance_spec_creation_failure(
+        self, mock_spec_from_file, mock_exists, mock_import_module
+    ):
+        """Test load_mcp_instance with spec creation failure."""
+        mock_import_module.side_effect = ImportError("No module")
+        mock_exists.return_value = True
+        mock_spec_from_file.return_value = None
+
+        with pytest.raises(ImportError) as exc_info:
+            load_mcp_instance("test/file:mcp")
+
+        assert "Cannot load module from test/file.py" in str(exc_info.value)
+
+    @patch("eunomia_mcp.cli.utils.importlib.import_module")
+    @patch("eunomia_mcp.cli.utils.os.path.exists")
+    @patch("eunomia_mcp.cli.utils.importlib.util.spec_from_file_location")
+    def test_load_mcp_instance_no_loader(
+        self, mock_spec_from_file, mock_exists, mock_import_module
+    ):
+        """Test load_mcp_instance with missing loader in spec."""
+        mock_import_module.side_effect = ImportError("No module")
+        mock_exists.return_value = True
+
+        mock_spec = Mock()
+        mock_spec.loader = None
+        mock_spec_from_file.return_value = mock_spec
+
+        with pytest.raises(ImportError) as exc_info:
+            load_mcp_instance("test/file:mcp")
+
+        assert "Cannot load module from test/file.py" in str(exc_info.value)
+
+
+class TestGenerateCustomPolicyFromMcp:
+    """Test the generate_custom_policy_from_mcp function."""
+
+    @pytest.fixture
+    def empty_mcp_server(self) -> FastMCP:
+        """Create an empty FastMCP server for testing."""
+        return FastMCP("empty-server")
+
+    @pytest.fixture
+    def simple_mcp_server(self) -> FastMCP:
+        """Create a simple FastMCP server with one tool."""
+        mcp = FastMCP("simple-server")
+
+        @mcp.tool()
+        def add(a: int, b: int) -> int:
+            """Add two numbers"""
+            return a + b
+
+        return mcp
+
+    @pytest.fixture
+    def full_mcp_server(self) -> FastMCP:
+        """Create FastMCP server with tools, resources, and prompts."""
+        mcp = FastMCP("full-server")
+
+        @mcp.tool()
+        def calculate(x: int, y: int) -> int:
+            """Calculate sum"""
+            return x + y
+
+        @mcp.resource("uri://test-resource")
+        def get_resource() -> str:
+            """Get test resource"""
+            return "test data"
+
+        @mcp.prompt("test-prompt")
+        def get_prompt() -> str:
+            """Get test prompt"""
+            return "test prompt"
+
+        return mcp
+
+    @pytest.fixture
+    def multi_tool_mcp_server(self) -> FastMCP:
+        """Create FastMCP server with multiple tools."""
+        mcp = FastMCP("multi-tools-server")
+
+        @mcp.tool()
+        def add_numbers(a: int, b: int) -> int:
+            """Add two numbers"""
+            return a + b
+
+        @mcp.tool()
+        def multiply_numbers(x: int, y: int) -> int:
+            """Multiply two numbers"""
+            return x * y
+
+        return mcp
+
+    @pytest.mark.asyncio
+    async def test_generate_custom_policy_empty_server(self, empty_mcp_server):
+        """Test generating policy from server with no components."""
+        policy = await generate_custom_policy_from_mcp(empty_mcp_server)
+
+        assert policy.version == "1.0"
+        assert policy.name == "empty-server-generated-policy"
+        assert policy.description == "Generated policy for MCP server: empty-server"
+        assert policy.default_effect == enums.PolicyEffect.DENY
+        assert len(policy.rules) == 0
+
+    @pytest.mark.asyncio
+    async def test_generate_custom_policy_with_tools_only(self, simple_mcp_server):
+        """Test generating policy from server with only tools."""
+        policy = await generate_custom_policy_from_mcp(simple_mcp_server)
+
+        assert policy.version == "1.0"
+        assert policy.name == "simple-server-generated-policy"
+        assert policy.default_effect == enums.PolicyEffect.DENY
+        assert len(policy.rules) == 2  # 1 list rule + 1 execute rule
+
+        # Check list rule
+        list_rule = policy.rules[0]
+        assert list_rule.name == "list-tools"
+        assert list_rule.effect == enums.PolicyEffect.ALLOW
+        assert list_rule.actions == ["list"]
+        assert len(list_rule.resource_conditions) == 2
+
+        # Check execute rule
+        execute_rule = policy.rules[1]
+        assert execute_rule.name == "execute-tools-add"
+        assert execute_rule.effect == enums.PolicyEffect.ALLOW
+        assert execute_rule.actions == ["execute"]
+
+    @pytest.mark.asyncio
+    async def test_generate_custom_policy_with_all_components(self, full_mcp_server):
+        """Test generating policy from server with all component types."""
+        policy = await generate_custom_policy_from_mcp(full_mcp_server)
+
+        assert policy.version == "1.0"
+        assert policy.name == "full-server-generated-policy"
+        assert policy.default_effect == enums.PolicyEffect.DENY
+        assert len(policy.rules) == 6  # 3 list rules + 3 execute rules
+
+        # Verify rule names
+        rule_names = [rule.name for rule in policy.rules]
+        expected_names = [
+            "list-tools",
+            "execute-tools-calculate",
+            "list-resources",
+            "execute-resources-get_resource",
+            "list-prompts",
+            "execute-prompts-test-prompt",
+        ]
+        assert rule_names == expected_names
+
+    @pytest.mark.asyncio
+    async def test_generate_custom_policy_with_multiple_tools(
+        self, multi_tool_mcp_server
+    ):
+        """Test generating policy from server with multiple tools."""
+        policy = await generate_custom_policy_from_mcp(multi_tool_mcp_server)
+
+        assert len(policy.rules) == 3  # 1 list rule + 2 execute rules
+
+        # Check list rule includes both tools
+        list_rule = policy.rules[0]
+        name_condition = next(
+            cond
+            for cond in list_rule.resource_conditions
+            if cond.path == "attributes.name"
+        )
+        assert set(name_condition.value) == {"add_numbers", "multiply_numbers"}
+
+        # Check individual execute rules
+        execute_rules = policy.rules[1:]
+        assert len(execute_rules) == 2
+        execute_rule_names = {rule.name for rule in execute_rules}
+        expected_execute_names = {
+            "execute-tools-add_numbers",
+            "execute-tools-multiply_numbers",
+        }
+        assert execute_rule_names == expected_execute_names
+
+    @pytest.mark.asyncio
+    async def test_generate_custom_policy_rule_structure(self, simple_mcp_server):
+        """Test the structure of generated rules."""
+        policy = await generate_custom_policy_from_mcp(simple_mcp_server)
+
+        list_rule = policy.rules[0]
+        execute_rule = policy.rules[1]
+
+        # Check list rule structure
+        assert list_rule.effect == enums.PolicyEffect.ALLOW
+        assert list_rule.principal_conditions == []
+        assert len(list_rule.resource_conditions) == 2
+
+        component_type_condition = list_rule.resource_conditions[0]
+        assert component_type_condition.path == "attributes.component_type"
+        assert component_type_condition.operator == enums.ConditionOperator.EQUALS
+        assert component_type_condition.value == "tools"
+
+        name_condition = list_rule.resource_conditions[1]
+        assert name_condition.path == "attributes.name"
+        assert name_condition.operator == enums.ConditionOperator.IN
+        assert name_condition.value == ["add"]
+
+        # Check execute rule structure
+        assert execute_rule.effect == enums.PolicyEffect.ALLOW
+        assert execute_rule.principal_conditions == []
+        assert len(execute_rule.resource_conditions) == 2
+
+        exec_component_type_condition = execute_rule.resource_conditions[0]
+        assert exec_component_type_condition.path == "attributes.component_type"
+        assert exec_component_type_condition.operator == enums.ConditionOperator.EQUALS
+        assert exec_component_type_condition.value == "tools"
+
+        exec_name_condition = execute_rule.resource_conditions[1]
+        assert exec_name_condition.path == "attributes.name"
+        assert exec_name_condition.operator == enums.ConditionOperator.EQUALS
+        assert exec_name_condition.value == "add"
+
+    def test_generate_custom_policy_sync_wrapper(self, empty_mcp_server):
+        """Test that the function can be called synchronously using asyncio.run."""
+        import asyncio
+
+        policy = asyncio.run(generate_custom_policy_from_mcp(empty_mcp_server))
+
+        assert isinstance(policy, schemas.Policy)
+        assert policy.name == "empty-server-generated-policy"


### PR DESCRIPTION
## Summary

**Main changes**:
- `eunomia-cli` tool allows to generate a customized policy by passing a FastMCP server instance to the `init` command, creating a custom policy that reflects the info of the provided MCP

**Minor changes**:
- Add an optional `description` field to rules schema
- Automatically slugify policy and rule names (to avoid broken paths)
- MCP methods `tools/call`, `resources/read`, `prompts/get` all maps to `execute` action
- Unit testing of new functionalities

### Breaking change
MCP methods `tools/call`, `resources/read`, `prompts/get` all maps to `execute` action

**Before**:
- `tools/call` method --> `call` action
- `resources/read` method --> `read` action
- `prompts/get` method --> `get` action

**After**:
- `tools/call` method --> `execute` action
- `resources/read` method --> `execute` action
- `prompts/get` method --> `execute` action

This change affects policies that were using `call`, `read` and `get` actions