### PR TITLE
Embedded Eunomia server within MCP server option

### DIFF
--- a/docs/mcp_middleware/advanced.md
+++ b/docs/mcp_middleware/advanced.md
@@ -28,11 +28,12 @@ middleware = create_eunomia_middleware(
 
 ### Middleware Configuration
 
-| Parameter              | Type   | Default                 | Description                            |
-| ---------------------- | ------ | ----------------------- | -------------------------------------- |
-| `use_remote_eunomia`   | `bool` | `False`                 | Whether to use a remote Eunomia server |
-| `eunomia_endpoint`     | `str`  | `http://localhost:8421` | Eunomia remote server URL              |
-| `enable_audit_logging` | `bool` | `True`                  | Enable request/violation logging       |
+| Parameter              | Type   | Default                 | Description                                                                  |
+| ---------------------- | ------ | ----------------------- | ---------------------------------------------------------------------------- |
+| `policy_file`          | `str`  | `mcp_policies.json`     | Path to policy configuration JSON file, for **embedded** Eunomia server only |
+| `use_remote_eunomia`   | `bool` | `False`                 | Whether to use a remote Eunomia server                                       |
+| `eunomia_endpoint`     | `str`  | `http://localhost:8421` | Eunomia server URL, for **remote** Eunomia server only                       |
+| `enable_audit_logging` | `bool` | `True`                  | Enable request/violation logging                                             |
 
 ## Connect to Remote MCP Servers using a Proxy
 

--- a/docs/mcp_middleware/authentication.md
+++ b/docs/mcp_middleware/authentication.md
@@ -31,7 +31,7 @@ For advanced authentication scenarios, you can subclass the `EunomiaMcpMiddlewar
 
 ```python
 from eunomia_core import schemas
-from eunomia_mcp import EunomiaMcpMiddleware
+from eunomia_mcp.middleware import EunomiaMcpMiddleware
 from fastmcp.server.dependencies import get_http_headers
 
 

--- a/docs/mcp_middleware/index.md
+++ b/docs/mcp_middleware/index.md
@@ -12,9 +12,9 @@ With the Eunomia MCP Middleware, you can control which tools, resources and prom
 
 - 🔒 **Policy-Based Authorization**: Control which agents can access which MCP tools, resources, and prompts
 - 📊 **Audit Logging**: Track all authorization decisions and violations
+- 🔄 **Centralized Policy Enforcement**: Optionally use a remote Eunomia server for centralized policy enforcement
 - ⚡ **FastMCP Integration**: One-line middleware integration with FastMCP servers
 - 🔧 **Flexible Configuration**: JSON-based policies for complex dynamic rules with CLI tooling
-- 🎯 **MCP-Aware**: Built-in understanding of MCP protocol (tools, resources, prompts)
 
 ## How It Works
 
@@ -64,10 +64,6 @@ sequenceDiagram
 ```bash
 pip install eunomia-mcp
 ```
-
-!!! info
-
-    The middleware requires a running [Eunomia server](../server/pdp/run_server.md) to make authorization decisions.
 
 ## User Workflows
 

--- a/docs/mcp_middleware/policies.md
+++ b/docs/mcp_middleware/policies.md
@@ -28,6 +28,10 @@ eunomia-mcp validate mcp_policies.json
 
 ### Deploying Policies
 
+!!! info
+
+    This operation is needed only if you are using a [remote Eunomia server](advanced.md#centralize-policy-enforcement-with-a-remote-eunomia-server), otherwise you can skip this step.
+
 ```bash
 # Push your policy to Eunomia server
 eunomia-mcp push mcp_policies.json
@@ -36,11 +40,7 @@ eunomia-mcp push mcp_policies.json
 eunomia-mcp push mcp_policies.json --overwrite
 ```
 
-!!! info
-
-    You need the Eunomia server running for the push operation.
-
-Workflow:
+### Workflow Summary
 
 1.  **Initialize**: `eunomia-mcp init`
 
@@ -50,9 +50,11 @@ Workflow:
 
 2.  **Customize**: Edit generated policy file
 3.  **Validate**: `eunomia-mcp validate mcp_policies.json`
-4.  **Start Server**: Start Eunomia server (with `eunomia server` or other methods)
-5.  **Deploy**: `eunomia-mcp push mcp_policies.json`
-6.  **Run**: Run your MCP server with middleware
+4.  **Run**: Run your MCP server with middleware
+
+When using a [remote Eunomia server](advanced.md#centralize-policy-enforcement-with-a-remote-eunomia-server), you need to deploy the policy to it:
+
+-> **Deploy**: `eunomia-mcp push mcp_policies.json` -> **Run**
 
 ## MCP Context Extraction
 

--- a/docs/mcp_middleware/quickstart.md
+++ b/docs/mcp_middleware/quickstart.md
@@ -21,7 +21,7 @@ def add(a: int, b: int) -> int:
     return a + b
 
 # Add middleware to your server
-middleware = create_eunomia_middleware()
+middleware = create_eunomia_middleware(policy_file="mcp_policies.json")
 mcp.add_middleware(middleware)
 
 if __name__ == "__main__":

--- a/docs/mcp_middleware/quickstart.md
+++ b/docs/mcp_middleware/quickstart.md
@@ -10,35 +10,25 @@ pip install eunomia-mcp
 
 ```python title="server.py"
 from fastmcp import FastMCP
-from eunomia_mcp import EunomiaMcpMiddleware
+from eunomia_mcp import create_eunomia_middleware
 
-mcp = FastMCP("Secure FastMCP Server 🔒")
+# Create your FastMCP server
+mcp = FastMCP("Secure MCP Server 🔒")
 
 @mcp.tool()
 def add(a: int, b: int) -> int:
     """Add two numbers"""
     return a + b
 
-middleware = EunomiaMcpMiddleware()
+# Add middleware to your server
+middleware = create_eunomia_middleware()
 mcp.add_middleware(middleware)
 
 if __name__ == "__main__":
     mcp.run()
 ```
 
-## Step 3: Start Eunomia Server
-
-The middleware requires a running Eunomia server to make policy decisions.
-
-Run it in the background with Docker:
-
-```bash
-docker run -d -p 8421:8421 --name eunomia ttommitt/eunomia-server:latest
-```
-
-Or refer to the [Eunomia server documentation](../server/pdp/run_server.md) for additional configuration options.
-
-## Step 4: Start Your Server
+## Step 3: Use Your Server
 
 You can now run your MCP server normally:
 

--- a/docs/server/pdp/run_server.md
+++ b/docs/server/pdp/run_server.md
@@ -10,6 +10,7 @@ To run the Eunomia server, you must configure the following parameters:
 | ------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------- |
 | `PROJECT_NAME`            | Name of the project                                         | `Eunomia Server`                                                        |
 | `DEBUG`                   | Flag to enable debug mode                                   | `False`                                                                 |
+| `ENGINE_SQL_DATABASE`     | Flag to enable persistence of policies in a database        | `True`                                                                  |
 | `ENGINE_SQL_DATABASE_URL` | Path to the policy database file                            | `sqlite:///.db/eunomia_db.sqlite`                                       |
 | `FETCHERS`                | Dictionary of fetchers to use                               | `{"registry": {"sql_database_url": "sqlite:///.db/eunomia_db.sqlite"}}` |
 | `ADMIN_API_KEY`           | Optional pre-shared key for Admin API authentication        | `None`                                                                  |

--- a/examples/mcp_planetary_weather/planetary_weather.py
+++ b/examples/mcp_planetary_weather/planetary_weather.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from eunomia_mcp.middleware import EunomiaMcpMiddleware
+from eunomia_mcp import create_eunomia_middleware
 from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
@@ -41,7 +41,8 @@ def get_venus_weather(request: WeatherRequest) -> str:
     return f"The weather on Venus at {request.time} was extremely hot (462°C) with sulfuric acid rain"
 
 
-mcp.add_middleware(EunomiaMcpMiddleware())
+middleware = create_eunomia_middleware()
+mcp.add_middleware(middleware)
 
 if __name__ == "__main__":
     mcp.run()

--- a/pkgs/core/pyproject.toml
+++ b/pkgs/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eunomia-core"
-version = "0.3.8"
+version = "0.3.9"
 description = "Shared functionalities for Eunomia packages"
 authors = [
     { name="What About You team", email="info@whataboutyou.ai" }

--- a/pkgs/extensions/langchain/pyproject.toml
+++ b/pkgs/extensions/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eunomia-langchain"
-version = "0.3.8"
+version = "0.3.9"
 description = "Eunomia extension for LangChain"
 authors = [
     { name="What About You team", email="info@whataboutyou.ai" }
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "eunomia-sdk>=0.3.8",
+    "eunomia-sdk>=0.3.9",
     "langchain>=0.3.20",
     "langchain-core>=0.3.41",
 ]

--- a/pkgs/extensions/mcp/README.md
+++ b/pkgs/extensions/mcp/README.md
@@ -11,9 +11,9 @@ Add **policy-based authorization** to your [MCP][mcp-docs] servers built on [Fas
 
 - 🔒 **Policy-Based Authorization**: Control which agents can access which MCP tools, resources, and prompts
 - 📊 **Audit Logging**: Track all authorization decisions and violations
+- 🔄 **Centralized Policy Enforcement**: Optionally use a remote Eunomia server for centralized policy enforcement
 - ⚡ **FastMCP Integration**: One-line middleware integration with FastMCP servers
 - 🔧 **Flexible Configuration**: JSON-based policies for complex dynamic rules with CLI tooling
-- 🎯 **MCP-Aware**: Built-in understanding of MCP protocol (tools, resources, prompts)
 
 ### Architecture
 
@@ -68,11 +68,11 @@ pip install eunomia-mcp
 
 ### Create a MCP Server with Middleware
 
-#### Basic Integration
+#### Basic Integration with embedded Eunomia server
 
 ```python
 from fastmcp import FastMCP
-from eunomia_mcp import EunomiaMcpMiddleware
+from eunomia_mcp import create_eunomia_middleware
 
 # Create your FastMCP server
 mcp = FastMCP("Secure MCP Server 🔒")
@@ -82,29 +82,15 @@ def add(a: int, b: int) -> int:
     """Add two numbers"""
     return a + b
 
-# Add Eunomia authorization middleware
-middleware = EunomiaMcpMiddleware()
-
-# Apply middleware to MCP server
+# Add middleware to your server
+middleware = create_eunomia_middleware()
 mcp.add_middleware(middleware)
 
 if __name__ == "__main__":
     mcp.run()
 ```
 
-> [!IMPORTANT]
->
-> [Eunomia][eunomia-github] is a standalone server that handles the policy decisions, you must have it running alongside the MCP server.
->
-> Run it in the background with Docker:
->
-> ```bash
-> docker run -d -p 8421:8421 --name eunomia ttommitt/eunomia-server:latest
-> ```
->
-> Or refer to the [Eunomia documentation][eunomia-docs-run-server] for more options.
-
-#### Advanced Integration
+#### Advanced Integration with remote Eunomia server
 
 Configure the middleware with custom options for production deployments:
 
@@ -116,13 +102,26 @@ mcp = FastMCP("Secure MCP Server 🔒")
 
 # Configure middleware with custom options
 middleware = create_eunomia_middleware(
+    use_remote_eunomia=True,
     eunomia_endpoint="https://your-eunomia-server.com",
-    eunomia_api_key="your-api-key",
     enable_audit_logging=True,
 )
 
 mcp.add_middleware(middleware)
 ```
+
+> [!IMPORTANT]
+>
+> You can use [Eunomia][eunomia-github] as a centralized policy decision point for multiple MCP servers,
+> which is especially relevant in enterprise scenarios.
+>
+> You can run the Eunomia server in the background with Docker:
+>
+> ```bash
+> docker run -d -p 8421:8421 --name eunomia ttommitt/eunomia-server:latest
+> ```
+>
+> Or refer to [Eunomia documentation][eunomia-docs-run-server] for additional running options.
 
 ### Policy Configuration
 
@@ -207,7 +206,7 @@ You can customize principal extraction by subclassing the middleware:
 
 ```python
 from eunomia_core import schemas
-from eunomia_mcp import EunomiaMcpMiddleware
+from eunomia_mcp.middleware import EunomiaMcpMiddleware
 
 class CustomAuthMiddleware(EunomiaMcpMiddleware):
     def _extract_principal(self) -> schemas.PrincipalCheck:
@@ -241,6 +240,8 @@ logger = logging.getLogger("eunomia_mcp")
 ### [(Sample) Planetary Weather MCP][example-planetary-weather-mcp]
 
 ### [WhatsApp MCP to Authorized Contacts][example-whatsapp-mcp]
+
+## Documentation
 
 Explore the detailed [documentation][eunomia-docs-mcp-middleware] for more advanced configuration and scenarios.
 

--- a/pkgs/extensions/mcp/README.md
+++ b/pkgs/extensions/mcp/README.md
@@ -83,7 +83,7 @@ def add(a: int, b: int) -> int:
     return a + b
 
 # Add middleware to your server
-middleware = create_eunomia_middleware()
+middleware = create_eunomia_middleware(policy_file="mcp_policies.json")
 mcp.add_middleware(middleware)
 
 if __name__ == "__main__":

--- a/pkgs/extensions/mcp/pyproject.toml
+++ b/pkgs/extensions/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eunomia-mcp"
-version = "0.3.8"
+version = "0.3.9"
 description = "Eunomia MCP authorization middleware"
 authors = [
     { name="What About You team", email="info@whataboutyou.ai" }
@@ -9,8 +9,8 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "eunomia-ai>=0.3.8",
-    "eunomia-sdk>=0.3.8",
+    "eunomia-ai>=0.3.9",
+    "eunomia-sdk>=0.3.9",
     "fastmcp>=2.10.4",
     "pydantic>=2.11.7",
     "typer>=0.15.2",

--- a/pkgs/extensions/mcp/pyproject.toml
+++ b/pkgs/extensions/mcp/pyproject.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "eunomia-ai>=0.3.8",
     "eunomia-sdk>=0.3.8",
     "fastmcp>=2.10.4",
     "pydantic>=2.11.7",
@@ -26,4 +27,5 @@ build-backend = "hatchling.build"
 packages = ["src/eunomia_mcp"]
 
 [tool.uv.sources]
+eunomia-ai = { workspace = true }
 eunomia-sdk = { workspace = true }

--- a/pkgs/extensions/mcp/src/eunomia_mcp/__init__.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/__init__.py
@@ -1,4 +1,3 @@
-from .middleware import EunomiaMcpMiddleware
 from .utils import create_eunomia_middleware
 
-__all__ = ["EunomiaMcpMiddleware", "create_eunomia_middleware"]
+__all__ = ["create_eunomia_middleware"]

--- a/pkgs/extensions/mcp/src/eunomia_mcp/bridge.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/bridge.py
@@ -1,0 +1,53 @@
+import logging
+from enum import Enum
+
+from eunomia_core import schemas
+from eunomia_sdk import EunomiaClient
+
+from eunomia.server import EunomiaServer
+
+logger = logging.getLogger(__name__)
+
+
+class EunomiaMode(Enum):
+    CLIENT = "client"
+    SERVER = "server"
+
+
+class EunomiaBridge:
+    _client: EunomiaClient | None = None
+    _server: EunomiaServer | None = None
+
+    def __init__(
+        self,
+        mode: EunomiaMode,
+        client: EunomiaClient | None = None,
+        server: EunomiaServer | None = None,
+    ):
+        self.mode = mode
+        if mode == EunomiaMode.CLIENT:
+            self._client = client or EunomiaClient()
+        elif mode == EunomiaMode.SERVER:
+            self._server = server or EunomiaServer()
+        else:
+            raise ValueError(f"Invalid mode: {mode}")
+
+    async def check(self, request: schemas.CheckRequest) -> schemas.CheckResponse:
+        if self.mode == EunomiaMode.CLIENT:
+            return self._client.check(
+                principal_uri=request.principal.uri,
+                principal_attributes=request.principal.attributes,
+                resource_uri=request.resource.uri,
+                resource_attributes=request.resource.attributes,
+                action=request.action,
+            )
+        else:
+            return await self._server.check(request)
+
+    async def bulk_check(
+        self, requests: list[schemas.CheckRequest]
+    ) -> list[schemas.CheckResponse]:
+        if self.mode == EunomiaMode.CLIENT:
+            return self._client.bulk_check(requests)
+        else:
+            return await self._server.bulk_check(requests)

--- a/pkgs/extensions/mcp/src/eunomia_mcp/cli/main.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/cli/main.py
@@ -11,9 +11,9 @@ from eunomia_mcp.cli.utils import (
     SAMPLE_SERVER_CODE,
     generate_custom_policy_from_mcp,
     load_mcp_instance,
-    load_policy_config,
     push_policy_config,
 )
+from eunomia_mcp.utils import load_policy_config
 
 app = typer.Typer(
     name="eunomia-mcp",
@@ -122,7 +122,7 @@ def push(
         help="Eunomia server API key",
     ),
 ):
-    """Push a policy configuration file to Eunomia."""
+    """Push a policy configuration file to a remote Eunomia server."""
     if overwrite:
         if not typer.confirm(
             "Are you sure you want to push this policy to Eunomia "
@@ -134,7 +134,7 @@ def push(
     try:
         client = EunomiaClient(endpoint=eunomia_endpoint, api_key=eunomia_api_key)
         push_policy_config(policy_file, overwrite, client)
-        typer.echo(f"Policy file {policy_file} pushed to Eunomia")
+        typer.echo(f"Policy file {policy_file} pushed to Eunomia at {client._endpoint}")
 
     except Exception as e:
         typer.echo(f"Error pushing policy: {e}", err=True)

--- a/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
@@ -27,7 +27,7 @@ DEFAULT_POLICY = schemas.Policy(
 
 SAMPLE_SERVER_CODE = '''
 from fastmcp import FastMCP
-from eunomia_mcp import EunomiaMcpMiddleware
+from eunomia_mcp import create_eunomia_middleware
 
 # Create your FastMCP server
 mcp = FastMCP("Secure MCP Server 🔒")
@@ -37,10 +37,8 @@ def add(a: int, b: int) -> int:
     """Add two numbers"""
     return a + b
 
-# Add Eunomia authorization middleware
-middleware = EunomiaMcpMiddleware()
-
-# Apply middleware to MCP server
+# Add middleware to your server
+middleware = create_eunomia_middleware()
 mcp.add_middleware(middleware)
 
 if __name__ == "__main__":

--- a/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
@@ -1,6 +1,5 @@
 import asyncio
 import importlib.util
-import os
 import sys
 
 from eunomia_core import enums, schemas
@@ -8,7 +7,7 @@ from eunomia_sdk import EunomiaClient
 from fastmcp import FastMCP
 from fastmcp.utilities.components import FastMCPComponent
 
-from eunomia_mcp.utils import load_policy_config
+from eunomia_mcp.utils import get_filepath, load_policy_config
 
 DEFAULT_POLICY = schemas.Policy(
     version="1.0",
@@ -99,8 +98,14 @@ def load_mcp_instance(mcp_path: str) -> FastMCP:
         module = importlib.import_module(module_path)
     except ImportError:
         # If direct import fails, try loading as file path
-        full_path = module_path if module_path.endswith(".py") else module_path + ".py"
-        if os.path.exists(full_path):
+        try:
+            full_path = get_filepath(
+                module_path if module_path.endswith(".py") else module_path + ".py"
+            )
+        except FileNotFoundError:
+            raise ImportError(f"Cannot import module: {module_path}")
+
+        if full_path.exists():
             spec = importlib.util.spec_from_file_location("custom_mcp", full_path)
             if spec is None or spec.loader is None:
                 raise ImportError(f"Cannot load module from {full_path}")

--- a/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
@@ -117,6 +117,14 @@ def load_mcp_instance(mcp_path: str) -> FastMCP:
     mcp_instance = getattr(module, variable_name)
 
     if not isinstance(mcp_instance, FastMCP):
+        from mcp.server.fastmcp import FastMCP as FastMCPv1
+
+        if isinstance(mcp_instance, FastMCPv1):
+            raise TypeError(
+                f"Object at {mcp_path} is not a FastMCP v2 instance. "
+                f"Got a FastMCP v1 instance instead. "
+                "Please upgrade your MCP server to FastMCP v2."
+            )
         raise TypeError(
             f"Object at {mcp_path} is not a FastMCP instance. "
             f"Got {type(mcp_instance).__name__}"
@@ -125,7 +133,7 @@ def load_mcp_instance(mcp_path: str) -> FastMCP:
     return mcp_instance
 
 
-def custom_list_rule(component_type: str, component_names: list[str]) -> schemas.Rule:
+def _custom_list_rule(component_type: str, component_names: list[str]) -> schemas.Rule:
     return schemas.Rule(
         name=f"list-{component_type}",
         description=f"List all {component_type} (tip: exclude from `attributes.name`'s values the ones that you want to hide from the MCP client)",
@@ -147,7 +155,7 @@ def custom_list_rule(component_type: str, component_names: list[str]) -> schemas
     )
 
 
-def custom_execute_rules(
+def _custom_execute_rules(
     component_type: str, components: list[FastMCPComponent]
 ) -> list[schemas.Rule]:
     rules = []
@@ -194,18 +202,18 @@ async def generate_custom_policy_from_mcp(mcp: FastMCP) -> schemas.Policy:
 
     if tools:
         rules.extend(
-            [custom_list_rule("tools", list(tools.keys()))]
-            + custom_execute_rules("tools", list(tools.values()))
+            [_custom_list_rule("tools", list(tools.keys()))]
+            + _custom_execute_rules("tools", list(tools.values()))
         )
     if resources:
         rules.extend(
-            [custom_list_rule("resources", list(resources.keys()))]
-            + custom_execute_rules("resources", list(resources.values()))
+            [_custom_list_rule("resources", list(resources.keys()))]
+            + _custom_execute_rules("resources", list(resources.values()))
         )
     if prompts:
         rules.extend(
-            [custom_list_rule("prompts", list(prompts.keys()))]
-            + custom_execute_rules("prompts", list(prompts.values()))
+            [_custom_list_rule("prompts", list(prompts.keys()))]
+            + _custom_execute_rules("prompts", list(prompts.values()))
         )
 
     return schemas.Policy(

--- a/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/cli/utils.py
@@ -8,6 +8,8 @@ from eunomia_sdk import EunomiaClient
 from fastmcp import FastMCP
 from fastmcp.utilities.components import FastMCPComponent
 
+from eunomia_mcp.utils import load_policy_config
+
 DEFAULT_POLICY = schemas.Policy(
     version="1.0",
     name="mcp-default-policy",
@@ -38,29 +40,12 @@ def add(a: int, b: int) -> int:
     return a + b
 
 # Add middleware to your server
-middleware = create_eunomia_middleware()
+middleware = create_eunomia_middleware(policy_file="mcp_policies.json")
 mcp.add_middleware(middleware)
 
 if __name__ == "__main__":
     mcp.run()
 '''
-
-
-def load_policy_config(policy_file: str) -> schemas.Policy:
-    """
-    Load policy configuration from a JSON file.
-
-    Args:
-        policy_file: Path to policy configuration JSON file
-
-    Returns:
-        Policy configuration dictionary
-    """
-    if not os.path.exists(policy_file):
-        raise FileNotFoundError(f"Policy file not found: {policy_file}")
-
-    with open(policy_file, "r") as f:
-        return schemas.Policy.model_validate_json(f.read())
 
 
 def push_policy_config(

--- a/pkgs/extensions/mcp/src/eunomia_mcp/utils.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/utils.py
@@ -1,7 +1,9 @@
+import inspect
+from pathlib import Path
 from typing import Optional
 
+from eunomia_core import schemas
 from eunomia_sdk import EunomiaClient
-from fastmcp.server.middleware import Middleware
 
 from eunomia.config import settings
 from eunomia.server import EunomiaServer
@@ -9,16 +11,103 @@ from eunomia_mcp.bridge import EunomiaMode
 from eunomia_mcp.middleware import EunomiaMcpMiddleware
 
 
+def load_policy_config(policy_file: str) -> schemas.Policy:
+    """
+    Load policy configuration from a JSON file.
+
+    Args:
+        policy_file: Path to policy configuration JSON file
+
+    Returns:
+        Policy configuration dictionary
+    """
+    policy_path = _get_filepath(policy_file)
+
+    with open(policy_path, "r") as f:
+        return schemas.Policy.model_validate_json(f.read())
+
+
+def _get_filepath(path_str: str) -> Path:
+    path = Path(path_str)
+
+    # Strategy 1: Try the provided path as-is (works for absolute paths and correct relative paths)
+    if path.exists():
+        resolved_path = path.resolve()
+    else:
+        # Strategy 2: Try relative to current working directory
+        cwd_success = False
+        try:
+            cwd_path = Path.cwd() / path_str
+            if cwd_path.exists():
+                resolved_path = cwd_path.resolve()
+                cwd_success = True
+        except (OSError, FileNotFoundError):
+            # Current working directory doesn't exist, skip this strategy
+            pass
+
+        if not cwd_success:
+            # Strategy 3: Try relative to external caller's directory
+            caller_dir = _get_external_caller_directory()
+            caller_path = caller_dir / path_str
+            if caller_path.exists():
+                resolved_path = caller_path.resolve()
+
+            else:
+                # Strategy 4: None of the strategies worked, raise error
+                # Build error message with paths that were actually tried
+                error_parts = ["Policy file not found. Tried:"]
+                error_parts.append(f"  - As provided: {path.resolve()}")
+                try:
+                    cwd_resolved = Path.cwd() / path_str
+                    error_parts.append(f"  - Relative to CWD: {cwd_resolved.resolve()}")
+                except (OSError, FileNotFoundError):
+                    error_parts.append(
+                        "  - Relative to CWD: (current directory not available)"
+                    )
+                error_parts.append(f"  - Relative to caller: {caller_path.resolve()}")
+
+                raise FileNotFoundError("\n".join(error_parts))
+
+    return resolved_path
+
+
+def _get_external_caller_directory() -> Path:
+    """
+    Get the directory of the first caller outside of the eunomia_mcp package.
+
+    Returns:
+        Path to the external caller's directory
+    """
+    frame = inspect.currentframe()
+
+    while frame is not None:
+        frame = frame.f_back
+        if frame is None:
+            break
+
+        frame_filename = frame.f_code.co_filename
+        # Skip frames within the eunomia_mcp package to find the original external caller
+        if "eunomia_mcp" not in frame_filename:
+            return Path(frame_filename).parent
+
+    # Fallback to immediate caller if no external caller found
+    caller_frame = inspect.currentframe().f_back
+    return Path(caller_frame.f_code.co_filename).parent
+
+
 def create_eunomia_middleware(
+    policy_file: Optional[str] = None,
     use_remote_eunomia: bool = False,
     eunomia_endpoint: Optional[str] = None,
     enable_audit_logging: bool = True,
-) -> Middleware:
+) -> EunomiaMcpMiddleware:
     """
     Create Eunomia authorization middleware for FastMCP servers.
 
     Parameters
     ----------
+    policy_file : str, optional
+        Path to policy configuration JSON file (defaults to "mcp_policies.json")
     use_remote_eunomia : bool, optional
         Whether to use a remote Eunomia server (defaults to False)
     eunomia_endpoint : str, optional
@@ -32,14 +121,28 @@ def create_eunomia_middleware(
         FastMCP Middleware instance
     """
     client, server = None, None
+
     if use_remote_eunomia:
         mode = EunomiaMode.CLIENT
+
+        if policy_file is not None:
+            raise ValueError(
+                "policy_file is not supported when using a remote Eunomia server, use the CLI to push the policy to the server"
+            )
+
         client = EunomiaClient(endpoint=eunomia_endpoint)
+
     else:
         mode = EunomiaMode.SERVER
-        # enforce no database persistence
+
+        # enforce no database persistence and no dynamic fetchers
         settings.ENGINE_SQL_DATABASE = False
+        settings.FETCHERS = {}
         server = EunomiaServer()
+
+        # load policy from file
+        policy = load_policy_config(policy_file or "mcp_policies.json")
+        server.engine.add_policy(policy)
 
     return EunomiaMcpMiddleware(
         mode=mode,

--- a/pkgs/extensions/mcp/src/eunomia_mcp/utils.py
+++ b/pkgs/extensions/mcp/src/eunomia_mcp/utils.py
@@ -21,13 +21,13 @@ def load_policy_config(policy_file: str) -> schemas.Policy:
     Returns:
         Policy configuration dictionary
     """
-    policy_path = _get_filepath(policy_file)
+    policy_path = get_filepath(policy_file)
 
     with open(policy_path, "r") as f:
         return schemas.Policy.model_validate_json(f.read())
 
 
-def _get_filepath(path_str: str) -> Path:
+def get_filepath(path_str: str) -> Path:
     path = Path(path_str)
 
     # Strategy 1: Try the provided path as-is (works for absolute paths and correct relative paths)

--- a/pkgs/sdks/python/pyproject.toml
+++ b/pkgs/sdks/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eunomia-sdk"
-version = "0.3.8"
+version = "0.3.9"
 description = "Eunomia SDK for Python"
 authors = [
     { name="What About You team", email="info@whataboutyou.ai" }
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "eunomia-core>=0.3.8",
+    "eunomia-core>=0.3.9",
     "httpx>=0.28.1",
 ]
 

--- a/pkgs/sdks/typescript/package-lock.json
+++ b/pkgs/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eunomia-sdk",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eunomia-sdk",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.8.0"

--- a/pkgs/sdks/typescript/package.json
+++ b/pkgs/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eunomia-sdk",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Eunomia SDK for TypeScript",
   "keywords": [
     "eunomia",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eunomia-ai"
-version = "0.3.8"
+version = "0.3.9"
 description = "Authorization layer for AI Agents"
 authors = [
     { name="What About You team", email="info@whataboutyou.ai" }
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "eunomia-core>=0.3.8",
+    "eunomia-core>=0.3.9",
     "fastapi[standard]>=0.115.9",
     "httpx>=0.28.1",
     "pydantic-settings>=2.8.1",

--- a/src/eunomia/config.py
+++ b/src/eunomia/config.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     DEBUG: bool = False
 
     # Engine config
+    ENGINE_SQL_DATABASE: bool = True
     ENGINE_SQL_DATABASE_URL: str = "sqlite:///./.db/eunomia_db.sqlite"
 
     # Fetcher config

--- a/src/eunomia/server/main.py
+++ b/src/eunomia/server/main.py
@@ -5,6 +5,7 @@ from eunomia_core import schemas
 from eunomia.config import settings
 from eunomia.engine import PolicyEngine
 from eunomia.fetchers import FetcherFactory
+from eunomia.utils.batch_processor import BatchProcessor
 
 
 class EunomiaServer:
@@ -18,6 +19,9 @@ class EunomiaServer:
         self.engine = PolicyEngine()
         FetcherFactory.initialize_fetchers(settings.FETCHERS)
         self._fetchers = FetcherFactory.get_all_fetchers()
+        self._batch_processor = BatchProcessor(
+            batch_size=settings.BULK_CHECK_BATCH_SIZE
+        )
 
     async def _fetch_all_attributes(self, entity: schemas.EntityCheck) -> None:
         if entity.attributes is None:
@@ -73,3 +77,16 @@ class EunomiaServer:
             self._fetch_all_attributes(request.resource),
         )
         return self.engine.evaluate_all(request)
+
+    async def bulk_check(
+        self, requests: list[schemas.CheckRequest]
+    ) -> list[schemas.CheckResponse]:
+        if not requests:
+            raise ValueError("Empty request list")
+
+        if len(requests) > settings.BULK_CHECK_MAX_REQUESTS:
+            raise ValueError(
+                f"Too many requests. Maximum allowed: {settings.BULK_CHECK_MAX_REQUESTS}",
+            )
+
+        return await self._batch_processor.run(requests, self.check)

--- a/src/eunomia/server/main.py
+++ b/src/eunomia/server/main.py
@@ -27,7 +27,7 @@ class EunomiaServer:
         if entity.attributes is None:
             entity.attributes = {}
 
-        if entity.uri is not None:
+        if entity.uri and self._fetchers:
             # run all fetchers concurrently
             fetched_results = await asyncio.gather(
                 *[

--- a/src/eunomia/server/router.py
+++ b/src/eunomia/server/router.py
@@ -1,14 +1,11 @@
 from eunomia_core import schemas
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter
 
-from eunomia.config import settings
 from eunomia.server import EunomiaServer
-from eunomia.utils.batch_processor import BatchProcessor
 
 
 def server_router_factory(server: EunomiaServer) -> APIRouter:
     router = APIRouter()
-    batch_processor = BatchProcessor(batch_size=settings.BULK_CHECK_BATCH_SIZE)
 
     @router.post("/check", response_model=schemas.CheckResponse)
     async def check(request: schemas.CheckRequest):
@@ -16,16 +13,6 @@ def server_router_factory(server: EunomiaServer) -> APIRouter:
 
     @router.post("/check/bulk", response_model=list[schemas.CheckResponse])
     async def bulk_check(requests: list[schemas.CheckRequest]):
-        if not requests:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="Empty request list"
-            )
-        if len(requests) > settings.BULK_CHECK_MAX_REQUESTS:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Too many requests. Maximum allowed: {settings.BULK_CHECK_MAX_REQUESTS}",
-            )
-
-        return await batch_processor.run(requests, server.check)
+        return await server.bulk_check(requests)
 
     return router

--- a/tests/eunomia/engine/conftest.py
+++ b/tests/eunomia/engine/conftest.py
@@ -40,17 +40,23 @@ def fixture_db():
 
 
 @pytest.fixture
-def fixture_engine(monkeypatch):
-    """Create a PolicyEngine instance for testing with an in-memory database."""
-    # Set up a test database URL
+def engine_with_database(monkeypatch):
+    """Create a PolicyEngine instance with database persistence enabled."""
+    monkeypatch.setattr("eunomia.config.settings.ENGINE_SQL_DATABASE", True)
     monkeypatch.setattr(
         "eunomia.config.settings.ENGINE_SQL_DATABASE_URL", "sqlite:///:memory:"
     )
 
-    # Initialize the engine
     engine = PolicyEngine()
+    yield engine
 
-    # Return the engine for testing
+
+@pytest.fixture
+def engine_without_database(monkeypatch):
+    """Create a PolicyEngine instance with database persistence disabled."""
+    monkeypatch.setattr("eunomia.config.settings.ENGINE_SQL_DATABASE", False)
+
+    engine = PolicyEngine()
     yield engine
 
 

--- a/tests/eunomia/engine/test_engine.py
+++ b/tests/eunomia/engine/test_engine.py
@@ -3,59 +3,163 @@ from eunomia_core import enums, schemas
 from eunomia.engine import PolicyEngine
 
 
-def test_add_policy(fixture_engine: PolicyEngine, sample_policy: schemas.Policy):
-    fixture_engine.add_policy(sample_policy)
-    assert len(fixture_engine.policies) == 1
-    assert fixture_engine.policies[0].name == sample_policy.name
+class TestPolicyEngineWithDatabase:
+    """Test PolicyEngine functionality with database persistence enabled."""
+
+    def test_initialization(self, engine_with_database: PolicyEngine):
+        """Test that engine initializes correctly with database enabled."""
+        assert engine_with_database._db_enabled is True
+        assert len(engine_with_database.policies) == 0
+
+    def test_add_policy(
+        self, engine_with_database: PolicyEngine, sample_policy: schemas.Policy
+    ):
+        """Test adding policy with database persistence."""
+        engine_with_database.add_policy(sample_policy)
+        assert len(engine_with_database.policies) == 1
+        assert engine_with_database.policies[0].name == sample_policy.name
+
+    def test_remove_policy_success(
+        self, engine_with_database: PolicyEngine, sample_policy: schemas.Policy
+    ):
+        """Test removing existing policy with database persistence."""
+        engine_with_database.add_policy(sample_policy)
+        assert engine_with_database.remove_policy("test-policy") is True
+        assert len(engine_with_database.policies) == 0
+
+    def test_remove_policy_nonexistent(self, engine_with_database: PolicyEngine):
+        """Test removing non-existent policy with database persistence."""
+        assert engine_with_database.remove_policy("non-existent") is False
+
+    def test_get_policy_by_name(
+        self, engine_with_database: PolicyEngine, sample_policy: schemas.Policy
+    ):
+        """Test retrieving specific policy by name with database persistence."""
+        engine_with_database.add_policy(sample_policy)
+        retrieved = engine_with_database.get_policy("test-policy")
+        assert retrieved is not None
+        assert retrieved.name == sample_policy.name
+        assert engine_with_database.get_policy("non-existent") is None
+
+    def test_get_all_policies(
+        self, engine_with_database: PolicyEngine, sample_policy: schemas.Policy
+    ):
+        """Test retrieving all policies with database persistence."""
+        engine_with_database.add_policy(sample_policy)
+        policies = engine_with_database.get_policies()
+        assert len(policies) == 1
+        assert policies[0].name == sample_policy.name
 
 
-def test_remove_policy(fixture_engine: PolicyEngine, sample_policy: schemas.Policy):
-    fixture_engine.add_policy(sample_policy)
-    assert fixture_engine.remove_policy("test-policy") is True
-    assert len(fixture_engine.policies) == 0
-    assert fixture_engine.remove_policy("non-existent") is False
+class TestPolicyEngineWithoutDatabase:
+    """Test PolicyEngine functionality with database persistence disabled."""
+
+    def test_initialization(self, engine_without_database: PolicyEngine):
+        """Test that engine initializes correctly with database disabled."""
+        assert engine_without_database._db_enabled is False
+        assert len(engine_without_database.policies) == 0
+
+    def test_add_policy(
+        self, engine_without_database: PolicyEngine, sample_policy: schemas.Policy
+    ):
+        """Test adding policy without database persistence (memory only)."""
+        engine_without_database.add_policy(sample_policy)
+        assert len(engine_without_database.policies) == 1
+        assert engine_without_database.policies[0].name == sample_policy.name
+
+    def test_remove_policy_success(
+        self, engine_without_database: PolicyEngine, sample_policy: schemas.Policy
+    ):
+        """Test removing existing policy without database persistence."""
+        engine_without_database.add_policy(sample_policy)
+        assert engine_without_database.remove_policy("test-policy") is True
+        assert len(engine_without_database.policies) == 0
+
+    def test_remove_policy_nonexistent(self, engine_without_database: PolicyEngine):
+        """Test removing non-existent policy without database persistence."""
+        result = engine_without_database.remove_policy("non-existent")
+        assert result is False
+
+    def test_get_policy_by_name(
+        self, engine_without_database: PolicyEngine, sample_policy: schemas.Policy
+    ):
+        """Test retrieving specific policy by name without database persistence."""
+        engine_without_database.add_policy(sample_policy)
+        retrieved = engine_without_database.get_policy("test-policy")
+        assert retrieved is not None
+        assert retrieved.name == sample_policy.name
+        assert engine_without_database.get_policy("non-existent") is None
+
+    def test_get_all_policies(
+        self, engine_without_database: PolicyEngine, sample_policy: schemas.Policy
+    ):
+        """Test retrieving all policies without database persistence."""
+        engine_without_database.add_policy(sample_policy)
+        policies = engine_without_database.get_policies()
+        assert len(policies) == 1
+        assert policies[0].name == sample_policy.name
 
 
-def test_get_policy(fixture_engine: PolicyEngine, sample_policy: schemas.Policy):
-    fixture_engine.add_policy(sample_policy)
-    retrieved = fixture_engine.get_policy("test-policy")
-    assert retrieved.name == sample_policy.name
-    assert fixture_engine.get_policy("non-existent") is None
+class TestPolicyEngineEvaluation:
+    """Test PolicyEngine evaluation logic (independent of persistence mode)."""
 
+    def test_evaluate_with_no_policies(
+        self,
+        engine_with_database: PolicyEngine,
+        sample_access_request: schemas.CheckRequest,
+    ):
+        """Test evaluation when no policies are loaded."""
+        result = engine_with_database.evaluate_all(sample_access_request)
+        assert result.allowed is False
+        assert "default" in result.reason
 
-def test_evaluate_all_with_no_policies(
-    fixture_engine: PolicyEngine, sample_access_request: schemas.CheckRequest
-):
-    result = fixture_engine.evaluate_all(sample_access_request)
-    assert result.allowed is False
-    assert "default" in result.reason
+    def test_evaluate_with_matching_policy(
+        self,
+        engine_with_database: PolicyEngine,
+        sample_policy: schemas.Policy,
+        sample_access_request: schemas.CheckRequest,
+    ):
+        """Test evaluation with a policy that matches the request."""
+        engine_with_database.add_policy(sample_policy)
+        result = engine_with_database.evaluate_all(sample_access_request)
+        assert result.allowed is True
+        assert "test-policy" in result.reason
 
+    def test_evaluate_with_non_matching_policy(
+        self, engine_with_database: PolicyEngine, sample_policy: schemas.Policy
+    ):
+        """Test evaluation with a policy that doesn't match the request."""
+        non_matching_request = schemas.CheckRequest(
+            principal=schemas.PrincipalCheck(
+                type=enums.EntityType.principal,
+                attributes={"role": "user"},  # Different from required "admin"
+            ),
+            resource=schemas.ResourceCheck(
+                type=enums.EntityType.resource,
+                attributes={"name": "test-resource"},
+            ),
+            action="access",
+        )
+        engine_with_database.add_policy(sample_policy)
+        result = engine_with_database.evaluate_all(non_matching_request)
+        assert result.allowed is False
 
-def test_evaluate_all_with_matching_policy(
-    fixture_engine: PolicyEngine,
-    sample_policy: schemas.Policy,
-    sample_access_request: schemas.CheckRequest,
-):
-    fixture_engine.add_policy(sample_policy)
-    result = fixture_engine.evaluate_all(sample_access_request)
-    assert result.allowed is True
-    assert "test-policy" in result.reason
+    def test_evaluate_consistency_across_persistence_modes(
+        self,
+        engine_with_database: PolicyEngine,
+        engine_without_database: PolicyEngine,
+        sample_policy: schemas.Policy,
+        sample_access_request: schemas.CheckRequest,
+    ):
+        """Test that evaluation results are consistent regardless of persistence mode."""
+        # Add same policy to both engines
+        engine_with_database.add_policy(sample_policy)
+        engine_without_database.add_policy(sample_policy)
 
+        # Evaluate same request on both engines
+        result_with_db = engine_with_database.evaluate_all(sample_access_request)
+        result_without_db = engine_without_database.evaluate_all(sample_access_request)
 
-def test_evaluate_all_with_non_matching_policy(
-    fixture_engine: PolicyEngine, sample_policy: schemas.Policy
-):
-    non_matching_request = schemas.CheckRequest(
-        principal=schemas.PrincipalCheck(
-            type=enums.EntityType.principal,
-            attributes={"role": "user"},
-        ),
-        resource=schemas.ResourceCheck(
-            type=enums.EntityType.resource,
-            attributes={"name": "test-resource"},
-        ),
-        action="access",
-    )
-    fixture_engine.add_policy(sample_policy)
-    result = fixture_engine.evaluate_all(non_matching_request)
-    assert result.allowed is False
+        # Results should be identical
+        assert result_with_db.allowed == result_without_db.allowed
+        assert result_with_db.reason == result_without_db.reason

--- a/tests/eunomia/engine/test_integration.py
+++ b/tests/eunomia/engine/test_integration.py
@@ -4,7 +4,7 @@ from eunomia.engine import utils
 from eunomia.engine.engine import PolicyEngine
 
 
-def test_role_based_access(fixture_engine: PolicyEngine):
+def test_role_based_access(engine_with_database: PolicyEngine):
     """Test role-based access control policies."""
     admin_policy = utils.create_simple_policy(
         name="admin-access",
@@ -12,7 +12,7 @@ def test_role_based_access(fixture_engine: PolicyEngine):
         principal_attributes={"role": "admin"},
         effect=enums.PolicyEffect.ALLOW,
     )
-    fixture_engine.add_policy(admin_policy)
+    engine_with_database.add_policy(admin_policy)
 
     read_only_policy = schemas.Policy(
         version="1.0",
@@ -41,7 +41,7 @@ def test_role_based_access(fixture_engine: PolicyEngine):
         ],
         default_effect=enums.PolicyEffect.DENY,
     )
-    fixture_engine.add_policy(read_only_policy)
+    engine_with_database.add_policy(read_only_policy)
 
     admin_request = schemas.CheckRequest(
         principal=schemas.PrincipalCheck(
@@ -55,7 +55,7 @@ def test_role_based_access(fixture_engine: PolicyEngine):
         action="access",
     )
 
-    admin_result = fixture_engine.evaluate_all(admin_request)
+    admin_result = engine_with_database.evaluate_all(admin_request)
     assert admin_result.allowed is True
     assert "admin-access" in admin_result.reason
 
@@ -71,7 +71,7 @@ def test_role_based_access(fixture_engine: PolicyEngine):
         action="access",
     )
 
-    readonly_public_result = fixture_engine.evaluate_all(readonly_public_request)
+    readonly_public_result = engine_with_database.evaluate_all(readonly_public_request)
     assert readonly_public_result.allowed is True
     assert "read-only-access" in readonly_public_result.reason
 
@@ -87,5 +87,7 @@ def test_role_based_access(fixture_engine: PolicyEngine):
         action="access",
     )
 
-    readonly_private_result = fixture_engine.evaluate_all(readonly_private_request)
+    readonly_private_result = engine_with_database.evaluate_all(
+        readonly_private_request
+    )
     assert readonly_private_result.allowed is False

--- a/tests/eunomia_mcp/conftest.py
+++ b/tests/eunomia_mcp/conftest.py
@@ -47,4 +47,5 @@ def mock_eunomia_client():
     client.get_policies.return_value = []
     client.delete_policy.return_value = None
     client.create_policy.return_value = None
+    client._endpoint = "http://localhost:8421"
     return client

--- a/tests/eunomia_mcp/test_cli_main.py
+++ b/tests/eunomia_mcp/test_cli_main.py
@@ -397,7 +397,10 @@ class TestCLIIntegration:
         result = runner.invoke(app, ["push", "--help"])
 
         assert result.exit_code == 0
-        assert "Push a policy configuration file to Eunomia" in result.stdout
+        assert (
+            "Push a policy configuration file to a remote Eunomia server"
+            in result.stdout
+        )
 
     def test_no_args_shows_help(self, runner):
         """Test that CLI shows help when no arguments provided."""

--- a/tests/eunomia_mcp/test_cli_utils.py
+++ b/tests/eunomia_mcp/test_cli_utils.py
@@ -117,8 +117,8 @@ class TestConstants:
     def test_sample_server_code_structure(self):
         """Test that SAMPLE_SERVER_CODE contains expected components."""
         assert "from fastmcp import FastMCP" in SAMPLE_SERVER_CODE
-        assert "from eunomia_mcp import EunomiaMcpMiddleware" in SAMPLE_SERVER_CODE
-        assert "EunomiaMcpMiddleware()" in SAMPLE_SERVER_CODE
+        assert "from eunomia_mcp import create_eunomia_middleware" in SAMPLE_SERVER_CODE
+        assert "middleware = create_eunomia_middleware()" in SAMPLE_SERVER_CODE
         assert "@mcp.tool()" in SAMPLE_SERVER_CODE
         assert "def add(a: int, b: int) -> int:" in SAMPLE_SERVER_CODE
         assert "mcp.run" in SAMPLE_SERVER_CODE

--- a/tests/eunomia_mcp/test_cli_utils.py
+++ b/tests/eunomia_mcp/test_cli_utils.py
@@ -7,7 +7,6 @@ from eunomia_mcp.cli.utils import (
     SAMPLE_SERVER_CODE,
     generate_custom_policy_from_mcp,
     load_mcp_instance,
-    load_policy_config,
     push_policy_config,
 )
 from fastmcp import FastMCP
@@ -15,39 +14,6 @@ from fastmcp import FastMCP
 
 class TestCLIUtils:
     """Test CLI utility functions."""
-
-    def test_load_policy_config_success(self, sample_policy_file):
-        """Test successful policy loading."""
-        policy = load_policy_config(str(sample_policy_file))
-
-        assert isinstance(policy, schemas.Policy)
-        assert policy.name == "mcp-default-policy"
-        assert policy.version == "1.0"
-        assert policy.default_effect == enums.PolicyEffect.DENY
-        assert len(policy.rules) == len(DEFAULT_POLICY.rules)
-
-    def test_load_policy_config_file_not_found(self):
-        """Test policy loading with nonexistent file."""
-        with pytest.raises(FileNotFoundError) as exc_info:
-            load_policy_config("nonexistent.json")
-
-        assert "Policy file not found: nonexistent.json" in str(exc_info.value)
-
-    def test_load_policy_config_invalid_json(self, temp_dir):
-        """Test policy loading with invalid JSON."""
-        policy_file = temp_dir / "invalid.json"
-        policy_file.write_text('{"invalid": json}')
-
-        with pytest.raises(Exception):
-            load_policy_config(str(policy_file))
-
-    def test_load_policy_config_invalid_schema(self, temp_dir):
-        """Test policy loading with invalid policy schema."""
-        policy_file = temp_dir / "invalid_schema.json"
-        policy_file.write_text('{"invalid": "schema"}')
-
-        with pytest.raises(Exception):
-            load_policy_config(str(policy_file))
 
     def test_push_policy_config_success(self, sample_policy_file, mock_eunomia_client):
         """Test successful policy push."""
@@ -118,7 +84,10 @@ class TestConstants:
         """Test that SAMPLE_SERVER_CODE contains expected components."""
         assert "from fastmcp import FastMCP" in SAMPLE_SERVER_CODE
         assert "from eunomia_mcp import create_eunomia_middleware" in SAMPLE_SERVER_CODE
-        assert "middleware = create_eunomia_middleware()" in SAMPLE_SERVER_CODE
+        assert (
+            'middleware = create_eunomia_middleware(policy_file="mcp_policies.json")'
+            in SAMPLE_SERVER_CODE
+        )
         assert "@mcp.tool()" in SAMPLE_SERVER_CODE
         assert "def add(a: int, b: int) -> int:" in SAMPLE_SERVER_CODE
         assert "mcp.run" in SAMPLE_SERVER_CODE

--- a/tests/eunomia_mcp/test_cli_utils.py
+++ b/tests/eunomia_mcp/test_cli_utils.py
@@ -120,22 +120,142 @@ class TestLoadMcpInstance:
         mock_import_module.assert_called_once_with("test.module")
 
     @patch("eunomia_mcp.cli.utils.importlib.import_module")
-    @patch("eunomia_mcp.cli.utils.os.path.exists")
+    @patch("eunomia_mcp.cli.utils.get_filepath")
+    @patch("eunomia_mcp.cli.utils.importlib.util.spec_from_file_location")
+    @patch("eunomia_mcp.cli.utils.importlib.util.module_from_spec")
+    def test_load_mcp_instance_success_file_import_absolute_path(
+        self,
+        mock_module_from_spec,
+        mock_spec_from_file,
+        mock_get_filepath,
+        mock_import_module,
+    ):
+        """Test successful MCP instance loading via absolute file path."""
+        # Mock import_module to fail initially
+        mock_import_module.side_effect = ImportError(
+            "No module named '/abs/path/to/file'"
+        )
+
+        # Mock get_filepath to return an absolute path that exists
+        mock_path = Mock()
+        mock_path.exists.return_value = True
+        mock_get_filepath.return_value = mock_path
+
+        # Mock spec creation and module loading
+        mock_spec = Mock()
+        mock_loader = Mock()
+        mock_spec.loader = mock_loader
+        mock_spec_from_file.return_value = mock_spec
+
+        # Create real FastMCP instance
+        mcp = FastMCP("absolute-path-server")
+
+        @mcp.tool()
+        def absolute_tool() -> str:
+            """A tool from absolute path"""
+            return "absolute"
+
+        # Use a simple mock module without any async attributes
+        mock_module = type("MockModule", (), {})()
+        mock_module.server = mcp
+        mock_module_from_spec.return_value = mock_module
+
+        result = load_mcp_instance("/abs/path/to/file.py:server")
+
+        assert result == mcp
+        assert isinstance(result, FastMCP)
+        mock_import_module.assert_called_once_with("/abs/path/to/file.py")
+        mock_get_filepath.assert_called_once_with("/abs/path/to/file.py")
+        mock_spec_from_file.assert_called_once_with("custom_mcp", mock_path)
+        mock_loader.exec_module.assert_called_once_with(mock_module)
+
+    @patch("eunomia_mcp.cli.utils.importlib.import_module")
+    @patch("eunomia_mcp.cli.utils.get_filepath")
+    def test_load_mcp_instance_get_filepath_error(
+        self, mock_get_filepath, mock_import_module
+    ):
+        """Test load_mcp_instance when get_filepath raises an error."""
+        mock_import_module.side_effect = ImportError("No module named 'test'")
+
+        # Mock get_filepath to raise FileNotFoundError
+        mock_get_filepath.side_effect = FileNotFoundError(
+            "Policy file not found. Tried: ..."
+        )
+
+        with pytest.raises(ImportError) as exc_info:
+            load_mcp_instance("test/file:mcp")
+
+        assert "Cannot import module: test/file" in str(exc_info.value)
+        mock_get_filepath.assert_called_once_with("test/file.py")
+
+    @patch("eunomia_mcp.cli.utils.importlib.import_module")
+    @patch("eunomia_mcp.cli.utils.get_filepath")
+    @patch("eunomia_mcp.cli.utils.importlib.util.spec_from_file_location")
+    @patch("eunomia_mcp.cli.utils.importlib.util.module_from_spec")
+    def test_load_mcp_instance_module_from_spec_with_add_py(
+        self,
+        mock_module_from_spec,
+        mock_spec_from_file,
+        mock_get_filepath,
+        mock_import_module,
+    ):
+        """Test loading MCP instance where module path needs .py extension added."""
+        # Mock import_module to fail initially
+        mock_import_module.side_effect = ImportError("No module named 'my_server'")
+
+        # Mock get_filepath to return a path that exists
+        mock_path = Mock()
+        mock_path.exists.return_value = True
+        mock_get_filepath.return_value = mock_path
+
+        # Mock spec creation and module loading
+        mock_spec = Mock()
+        mock_loader = Mock()
+        mock_spec.loader = mock_loader
+        mock_spec_from_file.return_value = mock_spec
+
+        # Create real FastMCP instance
+        mcp = FastMCP("my-server")
+
+        @mcp.resource("uri://test-resource-2")
+        def test_resource_2() -> str:
+            """Another test resource"""
+            return "test resource 2"
+
+        # Use a simple mock module without any async attributes
+        mock_module = type("MockModule", (), {})()
+        mock_module.my_mcp = mcp
+        mock_module_from_spec.return_value = mock_module
+
+        result = load_mcp_instance("my_server:my_mcp")
+
+        assert result == mcp
+        assert isinstance(result, FastMCP)
+        mock_import_module.assert_called_once_with("my_server")
+        # Should add .py extension when calling get_filepath
+        mock_get_filepath.assert_called_once_with("my_server.py")
+        mock_spec_from_file.assert_called_once_with("custom_mcp", mock_path)
+        mock_loader.exec_module.assert_called_once_with(mock_module)
+
+    @patch("eunomia_mcp.cli.utils.importlib.import_module")
+    @patch("eunomia_mcp.cli.utils.get_filepath")
     @patch("eunomia_mcp.cli.utils.importlib.util.spec_from_file_location")
     @patch("eunomia_mcp.cli.utils.importlib.util.module_from_spec")
     def test_load_mcp_instance_success_file_import(
         self,
         mock_module_from_spec,
         mock_spec_from_file,
-        mock_exists,
+        mock_get_filepath,
         mock_import_module,
     ):
         """Test successful MCP instance loading via file import."""
         # Mock import_module to fail initially
         mock_import_module.side_effect = ImportError("No module named 'test.file'")
 
-        # Mock file exists
-        mock_exists.return_value = True
+        # Mock get_filepath to return a path that exists
+        mock_path = Mock()
+        mock_path.exists.return_value = True
+        mock_get_filepath.return_value = mock_path
 
         # Mock spec creation and module loading
         mock_spec = Mock()
@@ -161,24 +281,28 @@ class TestLoadMcpInstance:
         assert result == mcp
         assert isinstance(result, FastMCP)
         mock_import_module.assert_called_once_with("test/file")
-        mock_exists.assert_called_once_with("test/file.py")
-        mock_spec_from_file.assert_called_once_with("custom_mcp", "test/file.py")
+        mock_get_filepath.assert_called_once_with("test/file.py")
+        mock_spec_from_file.assert_called_once_with("custom_mcp", mock_path)
         mock_loader.exec_module.assert_called_once_with(mock_module)
 
     @patch("eunomia_mcp.cli.utils.importlib.import_module")
-    @patch("eunomia_mcp.cli.utils.os.path.exists")
+    @patch("eunomia_mcp.cli.utils.get_filepath")
     @patch("eunomia_mcp.cli.utils.importlib.util.spec_from_file_location")
     @patch("eunomia_mcp.cli.utils.importlib.util.module_from_spec")
     def test_load_mcp_instance_success_file_import_with_py_extension(
         self,
         mock_module_from_spec,
         mock_spec_from_file,
-        mock_exists,
+        mock_get_filepath,
         mock_import_module,
     ):
         """Test successful MCP instance loading with .py extension."""
         mock_import_module.side_effect = ImportError("No module named 'test.file.py'")
-        mock_exists.return_value = True
+
+        # Mock get_filepath to return a path that exists
+        mock_path = Mock()
+        mock_path.exists.return_value = True
+        mock_get_filepath.return_value = mock_path
 
         mock_spec = Mock()
         mock_loader = Mock()
@@ -202,7 +326,7 @@ class TestLoadMcpInstance:
 
         assert result == mcp
         assert isinstance(result, FastMCP)
-        mock_spec_from_file.assert_called_once_with("custom_mcp", "test/file.py")
+        mock_spec_from_file.assert_called_once_with("custom_mcp", mock_path)
 
     def test_load_mcp_instance_invalid_path_format(self):
         """Test load_mcp_instance with invalid path format."""
@@ -213,13 +337,17 @@ class TestLoadMcpInstance:
         assert "Expected format: 'module.path:variable_name'" in str(exc_info.value)
 
     @patch("eunomia_mcp.cli.utils.importlib.import_module")
-    @patch("eunomia_mcp.cli.utils.os.path.exists")
+    @patch("eunomia_mcp.cli.utils.get_filepath")
     def test_load_mcp_instance_import_error_no_file(
-        self, mock_exists, mock_import_module
+        self, mock_get_filepath, mock_import_module
     ):
         """Test load_mcp_instance with import error and no file fallback."""
         mock_import_module.side_effect = ImportError("No module named 'nonexistent'")
-        mock_exists.return_value = False
+
+        # Mock get_filepath to return a path that doesn't exist
+        mock_path = Mock()
+        mock_path.exists.return_value = False
+        mock_get_filepath.return_value = mock_path
 
         with pytest.raises(ImportError) as exc_info:
             load_mcp_instance("nonexistent.module:mcp")
@@ -273,30 +401,39 @@ class TestLoadMcpInstance:
         assert "Got a FastMCP v1 instance instead" in str(exc_info.value)
 
     @patch("eunomia_mcp.cli.utils.importlib.import_module")
-    @patch("eunomia_mcp.cli.utils.os.path.exists")
+    @patch("eunomia_mcp.cli.utils.get_filepath")
     @patch("eunomia_mcp.cli.utils.importlib.util.spec_from_file_location")
     def test_load_mcp_instance_spec_creation_failure(
-        self, mock_spec_from_file, mock_exists, mock_import_module
+        self, mock_spec_from_file, mock_get_filepath, mock_import_module
     ):
         """Test load_mcp_instance with spec creation failure."""
         mock_import_module.side_effect = ImportError("No module")
-        mock_exists.return_value = True
+
+        # Mock get_filepath to return a path that exists
+        mock_path = Mock()
+        mock_path.exists.return_value = True
+        mock_get_filepath.return_value = mock_path
+
         mock_spec_from_file.return_value = None
 
         with pytest.raises(ImportError) as exc_info:
             load_mcp_instance("test/file:mcp")
 
-        assert "Cannot load module from test/file.py" in str(exc_info.value)
+        assert "Cannot load module from" in str(exc_info.value)
 
     @patch("eunomia_mcp.cli.utils.importlib.import_module")
-    @patch("eunomia_mcp.cli.utils.os.path.exists")
+    @patch("eunomia_mcp.cli.utils.get_filepath")
     @patch("eunomia_mcp.cli.utils.importlib.util.spec_from_file_location")
     def test_load_mcp_instance_no_loader(
-        self, mock_spec_from_file, mock_exists, mock_import_module
+        self, mock_spec_from_file, mock_get_filepath, mock_import_module
     ):
         """Test load_mcp_instance with missing loader in spec."""
         mock_import_module.side_effect = ImportError("No module")
-        mock_exists.return_value = True
+
+        # Mock get_filepath to return a path that exists
+        mock_path = Mock()
+        mock_path.exists.return_value = True
+        mock_get_filepath.return_value = mock_path
 
         mock_spec = Mock()
         mock_spec.loader = None
@@ -305,7 +442,7 @@ class TestLoadMcpInstance:
         with pytest.raises(ImportError) as exc_info:
             load_mcp_instance("test/file:mcp")
 
-        assert "Cannot load module from test/file.py" in str(exc_info.value)
+        assert "Cannot load module from" in str(exc_info.value)
 
 
 class TestGenerateCustomPolicyFromMcp:

--- a/tests/eunomia_mcp/test_cli_utils.py
+++ b/tests/eunomia_mcp/test_cli_utils.py
@@ -10,6 +10,7 @@ from eunomia_mcp.cli.utils import (
     push_policy_config,
 )
 from fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP as FastMCPv1
 
 
 class TestCLIUtils:
@@ -254,6 +255,22 @@ class TestLoadMcpInstance:
             exc_info.value
         )
         assert "Got str" in str(exc_info.value)
+
+    @patch("eunomia_mcp.cli.utils.importlib.import_module")
+    def test_load_mcp_instance_fastmcp_v1_instance(self, mock_import_module):
+        """Test load_mcp_instance with object that's a FastMCP v1 instance."""
+        # Create a simple mock module without any async attributes
+        mock_module = type("MockModule", (), {})()
+        mock_module.mcp = FastMCPv1("test-server")
+        mock_import_module.return_value = mock_module
+
+        with pytest.raises(TypeError) as exc_info:
+            load_mcp_instance("test.module:mcp")
+
+        assert "Object at test.module:mcp is not a FastMCP v2 instance" in str(
+            exc_info.value
+        )
+        assert "Got a FastMCP v1 instance instead" in str(exc_info.value)
 
     @patch("eunomia_mcp.cli.utils.importlib.import_module")
     @patch("eunomia_mcp.cli.utils.os.path.exists")

--- a/tests/eunomia_mcp/test_middleware_utils.py
+++ b/tests/eunomia_mcp/test_middleware_utils.py
@@ -1,0 +1,490 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+from eunomia_core import schemas
+from eunomia_mcp.middleware import EunomiaMcpMiddleware
+from eunomia_mcp.utils import (
+    _get_external_caller_directory,
+    _get_filepath,
+    create_eunomia_middleware,
+    load_policy_config,
+)
+from pydantic import ValidationError
+
+
+class TestLoadPolicyConfig:
+    """Test suite for load_policy_config function."""
+
+    def test_load_valid_policy_config(self, sample_policy_file):
+        """Test loading a valid policy configuration file."""
+        policy = load_policy_config(str(sample_policy_file))
+
+        assert isinstance(policy, schemas.Policy)
+        assert policy.name == "mcp-default-policy"
+        assert policy.version == "1.0"
+
+    def test_load_policy_config_with_mock_file(self):
+        """Test loading policy config with mocked file content."""
+        valid_policy_data = {"name": "Test Policy", "version": "1.0.0", "rules": []}
+
+        with patch("builtins.open", mock_open(read_data=json.dumps(valid_policy_data))):
+            with patch("eunomia_mcp.utils._get_filepath") as mock_get_filepath:
+                mock_get_filepath.return_value = Path("/mock/path/policy.json")
+
+                policy = load_policy_config("mock_policy.json")
+
+                assert isinstance(policy, schemas.Policy)
+                assert policy.name == "test-policy"  # Slugified name
+                assert policy.version == "1.0.0"
+
+    def test_load_policy_config_file_not_found(self):
+        """Test loading policy config when file doesn't exist."""
+        with patch("eunomia_mcp.utils._get_filepath") as mock_get_filepath:
+            mock_get_filepath.side_effect = FileNotFoundError("Policy file not found")
+
+            with pytest.raises(FileNotFoundError, match="Policy file not found"):
+                load_policy_config("nonexistent.json")
+
+    def test_load_policy_config_invalid_json(self):
+        """Test loading policy config with invalid JSON."""
+        invalid_json = "{ invalid json content"
+
+        with patch("builtins.open", mock_open(read_data=invalid_json)):
+            with patch("eunomia_mcp.utils._get_filepath") as mock_get_filepath:
+                mock_get_filepath.return_value = Path("/mock/path/policy.json")
+
+                with pytest.raises(
+                    ValidationError
+                ):  # Pydantic raises ValidationError for invalid JSON
+                    load_policy_config("invalid.json")
+
+    def test_load_policy_config_invalid_schema(self):
+        """Test loading policy config with invalid schema."""
+        invalid_policy_data = {"invalid": "schema"}
+
+        with patch(
+            "builtins.open", mock_open(read_data=json.dumps(invalid_policy_data))
+        ):
+            with patch("eunomia_mcp.utils._get_filepath") as mock_get_filepath:
+                mock_get_filepath.return_value = Path("/mock/path/policy.json")
+
+                with pytest.raises(ValidationError):
+                    load_policy_config("invalid_schema.json")
+
+
+class TestGetFilepath:
+    """Test suite for _get_filepath function."""
+
+    def test_strategy_1_absolute_path_exists(self, temp_dir):
+        """Test strategy 1: absolute path that exists."""
+        test_file = temp_dir / "test.json"
+        test_file.write_text('{"test": "data"}')
+
+        result = _get_filepath(str(test_file))
+
+        assert result == test_file.resolve()
+
+    def test_strategy_1_relative_path_exists(self, temp_dir):
+        """Test strategy 1: relative path that exists in current location."""
+        test_file = temp_dir / "test.json"
+        test_file.write_text('{"test": "data"}')
+
+        # Mock Path to control exists() behavior for strategy 1
+        original_path = Path
+
+        class MockPath(original_path):
+            def __new__(cls, *args, **kwargs):
+                instance = original_path.__new__(cls, *args, **kwargs)
+                return instance
+
+            def exists(self):
+                # Make relative path exist directly (strategy 1)
+                return str(self) == "test.json"
+
+            def resolve(self):
+                if str(self) == "test.json":
+                    return test_file.resolve()
+                return super().resolve()
+
+        with patch("eunomia_mcp.utils.Path", MockPath):
+            result = _get_filepath("test.json")
+            assert result == test_file.resolve()
+
+    @patch("pathlib.Path.cwd")
+    def test_strategy_2_relative_to_cwd(self, mock_cwd, temp_dir):
+        """Test strategy 2: relative to current working directory."""
+        test_file = temp_dir / "test.json"
+        test_file.write_text('{"test": "data"}')
+        mock_cwd.return_value = temp_dir
+
+        # Use a different working directory for the test
+        with patch("os.getcwd", return_value="/different/directory"):
+            result = _get_filepath("test.json")
+            assert result == test_file.resolve()
+
+    @patch("pathlib.Path.cwd")
+    def test_strategy_2_cwd_exception(self, mock_cwd, temp_dir):
+        """Test strategy 2: handle exception when CWD doesn't exist."""
+        mock_cwd.side_effect = OSError("Current directory not available")
+
+        test_file = temp_dir / "test.json"
+        test_file.write_text('{"test": "data"}')
+
+        with patch(
+            "eunomia_mcp.utils._get_external_caller_directory"
+        ) as mock_caller_dir:
+            mock_caller_dir.return_value = temp_dir
+
+            # Mock Path constructor to control exists() behavior
+            original_path = Path
+
+            class MockPath(original_path):
+                def __new__(cls, *args, **kwargs):
+                    instance = original_path.__new__(cls, *args, **kwargs)
+                    return instance
+
+                def exists(self):
+                    # Only return True for the caller directory path
+                    return str(self) == str(temp_dir / "test.json")
+
+            with patch("eunomia_mcp.utils.Path", MockPath):
+                result = _get_filepath("test.json")
+                assert result == test_file.resolve()
+
+    def test_strategy_3_relative_to_caller(self, temp_dir):
+        """Test strategy 3: relative to external caller's directory."""
+        test_file = temp_dir / "test.json"
+        test_file.write_text('{"test": "data"}')
+
+        with patch(
+            "eunomia_mcp.utils._get_external_caller_directory"
+        ) as mock_caller_dir:
+            mock_caller_dir.return_value = temp_dir
+
+            # Mock Path to control exists() behavior for different strategies
+            original_path = Path
+
+            class MockPath(original_path):
+                def __new__(cls, *args, **kwargs):
+                    instance = original_path.__new__(cls, *args, **kwargs)
+                    return instance
+
+                def exists(self):
+                    # Return False for direct path and CWD, True for caller path
+                    path_str = str(self)
+                    if path_str == "test.json":
+                        return False  # Direct path doesn't exist
+                    elif "/different/directory" in path_str:
+                        return False  # CWD path doesn't exist
+                    elif str(temp_dir) in path_str and "test.json" in path_str:
+                        return True  # Caller path exists
+                    return False
+
+            with patch("eunomia_mcp.utils.Path", MockPath):
+                with patch("pathlib.Path.cwd") as mock_cwd:
+                    mock_cwd.return_value = Path("/different/directory")
+
+                    result = _get_filepath("test.json")
+                    assert result == test_file.resolve()
+
+    def test_strategy_4_file_not_found_anywhere(self, temp_dir):
+        """Test strategy 4: file not found in any location."""
+        with patch(
+            "eunomia_mcp.utils._get_external_caller_directory"
+        ) as mock_caller_dir:
+            mock_caller_dir.return_value = temp_dir
+
+            # Mock Path to always return False for exists() and handle resolve() calls
+            original_path = Path
+
+            class MockPath(original_path):
+                def __new__(cls, *args, **kwargs):
+                    instance = original_path.__new__(cls, *args, **kwargs)
+                    return instance
+
+                def exists(self):
+                    return False
+
+                def resolve(self):
+                    # Handle resolve() calls safely to avoid CWD issues
+                    try:
+                        return super().resolve()
+                    except (OSError, FileNotFoundError):
+                        # Return a mock resolved path to avoid errors
+                        return Path("/mock/resolved") / self.name
+
+            with patch("eunomia_mcp.utils.Path", MockPath):
+                with patch("pathlib.Path.cwd") as mock_cwd:
+                    mock_cwd.return_value = Path("/different/directory")
+
+                    with pytest.raises(FileNotFoundError) as exc_info:
+                        _get_filepath("nonexistent.json")
+
+                    error_message = str(exc_info.value)
+                    assert "Policy file not found. Tried:" in error_message
+                    assert "As provided:" in error_message
+                    assert "Relative to CWD:" in error_message
+                    assert "Relative to caller:" in error_message
+
+    def test_strategy_4_cwd_not_available_error_message(self, temp_dir):
+        """Test strategy 4: error message when CWD is not available."""
+        with patch(
+            "eunomia_mcp.utils._get_external_caller_directory"
+        ) as mock_caller_dir:
+            mock_caller_dir.return_value = temp_dir
+
+            # Mock Path to always return False for exists() and handle resolve() calls
+            original_path = Path
+
+            class MockPath(original_path):
+                def __new__(cls, *args, **kwargs):
+                    instance = original_path.__new__(cls, *args, **kwargs)
+                    return instance
+
+                def exists(self):
+                    return False
+
+                def resolve(self):
+                    # Handle resolve() calls safely
+                    try:
+                        return super().resolve()
+                    except (OSError, FileNotFoundError):
+                        return Path("/mock/resolved") / self.name
+
+            with patch("eunomia_mcp.utils.Path", MockPath):
+                with patch("pathlib.Path.cwd") as mock_cwd:
+                    mock_cwd.side_effect = OSError("Directory not available")
+
+                    with pytest.raises(FileNotFoundError) as exc_info:
+                        _get_filepath("nonexistent.json")
+
+                    error_message = str(exc_info.value)
+                    assert "current directory not available" in error_message
+
+
+class TestGetExternalCallerDirectory:
+    """Test suite for _get_external_caller_directory function."""
+
+    def test_find_external_caller(self):
+        """Test finding external caller directory."""
+        # Mock the inspect.currentframe() to simulate call stack
+        with patch("inspect.currentframe") as mock_currentframe:
+            # Create mock frames
+            frame1 = Mock()
+            frame1.f_code.co_filename = "/path/to/eunomia_mcp/utils.py"
+            frame1.f_back = None
+
+            frame2 = Mock()
+            frame2.f_code.co_filename = "/path/to/external/caller.py"
+            frame2.f_back = frame1
+
+            frame3 = Mock()
+            frame3.f_code.co_filename = "/path/to/another/external/file.py"
+            frame3.f_back = frame2
+
+            mock_currentframe.return_value = frame3
+
+            result = _get_external_caller_directory()
+
+            # Should return the directory of the first non-eunomia_mcp file (frame2)
+            assert result == Path("/path/to/external")
+
+    def test_fallback_to_immediate_caller(self):
+        """Test fallback when no external caller is found."""
+        with patch("inspect.currentframe") as mock_currentframe:
+            # Create mock frames where all are from eunomia_mcp
+            frame1 = Mock()
+            frame1.f_code.co_filename = "/path/to/eunomia_mcp/utils.py"
+            frame1.f_back = None
+
+            frame2 = Mock()
+            frame2.f_code.co_filename = "/path/to/eunomia_mcp/middleware.py"
+            frame2.f_back = frame1
+
+            # Mock the immediate caller frame
+            caller_frame = Mock()
+            caller_frame.f_code.co_filename = "/path/to/immediate/caller.py"
+
+            mock_currentframe.return_value = frame2
+            mock_currentframe.return_value.f_back = caller_frame
+
+            result = _get_external_caller_directory()
+
+            assert result == Path("/path/to/immediate")
+
+    def test_no_frames_available(self):
+        """Test behavior when no frames are available."""
+        with patch("inspect.currentframe") as mock_currentframe:
+            mock_currentframe.return_value = None
+
+            # This should raise an AttributeError when trying to access f_back
+            with pytest.raises(AttributeError):
+                _get_external_caller_directory()
+
+
+class TestCreateEunomiaMiddleware:
+    """Test suite for create_eunomia_middleware function."""
+
+    @patch("eunomia_mcp.utils.EunomiaClient")
+    def test_create_middleware_remote_mode(self, mock_client_class):
+        """Test creating middleware in remote (CLIENT) mode."""
+        mock_client_instance = Mock()
+        mock_client_class.return_value = mock_client_instance
+
+        result = create_eunomia_middleware(
+            use_remote_eunomia=True,
+            eunomia_endpoint="http://example.com:8421",
+            enable_audit_logging=False,
+        )
+
+        assert isinstance(result, EunomiaMcpMiddleware)
+        mock_client_class.assert_called_once_with(endpoint="http://example.com:8421")
+
+    @patch("eunomia_mcp.utils.EunomiaServer")
+    @patch("eunomia_mcp.utils.load_policy_config")
+    @patch("eunomia_mcp.utils.settings")
+    def test_create_middleware_server_mode(
+        self, mock_settings, mock_load_policy, mock_server_class
+    ):
+        """Test creating middleware in server (local) mode."""
+        mock_server_instance = Mock()
+        mock_server_class.return_value = mock_server_instance
+
+        mock_policy = Mock(spec=schemas.Policy)
+        mock_load_policy.return_value = mock_policy
+
+        result = create_eunomia_middleware(
+            policy_file="test_policy.json",
+            use_remote_eunomia=False,
+            enable_audit_logging=True,
+        )
+
+        assert isinstance(result, EunomiaMcpMiddleware)
+        mock_load_policy.assert_called_once_with("test_policy.json")
+        mock_server_instance.engine.add_policy.assert_called_once_with(mock_policy)
+
+        # Verify settings were configured
+        assert mock_settings.ENGINE_SQL_DATABASE is False
+        assert mock_settings.FETCHERS == {}
+
+    def test_create_middleware_remote_with_policy_file_error(self):
+        """Test error when providing policy_file with remote Eunomia."""
+        with pytest.raises(
+            ValueError,
+            match="policy_file is not supported when using a remote Eunomia server",
+        ):
+            create_eunomia_middleware(
+                policy_file="test_policy.json", use_remote_eunomia=True
+            )
+
+    @patch("eunomia_mcp.utils.EunomiaServer")
+    @patch("eunomia_mcp.utils.load_policy_config")
+    @patch("eunomia_mcp.utils.settings")
+    def test_create_middleware_default_policy_file(
+        self, mock_settings, mock_load_policy, mock_server_class
+    ):
+        """Test creating middleware with default policy file."""
+        mock_server_instance = Mock()
+        mock_server_class.return_value = mock_server_instance
+
+        mock_policy = Mock(spec=schemas.Policy)
+        mock_load_policy.return_value = mock_policy
+
+        result = create_eunomia_middleware()
+
+        assert isinstance(result, EunomiaMcpMiddleware)
+        mock_load_policy.assert_called_once_with("mcp_policies.json")
+
+    @patch("eunomia_mcp.utils.EunomiaClient")
+    def test_create_middleware_remote_default_endpoint(self, mock_client_class):
+        """Test creating middleware with remote mode and default endpoint."""
+        mock_client_instance = Mock()
+        mock_client_class.return_value = mock_client_instance
+
+        result = create_eunomia_middleware(use_remote_eunomia=True)
+
+        assert isinstance(result, EunomiaMcpMiddleware)
+        mock_client_class.assert_called_once_with(endpoint=None)
+
+    @patch("eunomia_mcp.utils.EunomiaServer")
+    @patch("eunomia_mcp.utils.load_policy_config")
+    @patch("eunomia_mcp.utils.settings")
+    def test_create_middleware_custom_policy_file(
+        self, mock_settings, mock_load_policy, mock_server_class
+    ):
+        """Test creating middleware with custom policy file."""
+        mock_server_instance = Mock()
+        mock_server_class.return_value = mock_server_instance
+
+        mock_policy = Mock(spec=schemas.Policy)
+        mock_load_policy.return_value = mock_policy
+
+        result = create_eunomia_middleware(
+            policy_file="custom_policy.json", enable_audit_logging=False
+        )
+
+        assert isinstance(result, EunomiaMcpMiddleware)
+        mock_load_policy.assert_called_once_with("custom_policy.json")
+
+
+# Integration tests for edge cases
+class TestUtilsIntegration:
+    """Integration tests for utils module."""
+
+    def test_load_policy_config_integration(self, sample_policy_file):
+        """Test load_policy_config integration with real file."""
+        policy = load_policy_config(str(sample_policy_file))
+
+        assert isinstance(policy, schemas.Policy)
+        assert hasattr(policy, "name")
+        assert hasattr(policy, "version")
+
+    def test_get_filepath_integration_with_temp_file(self, temp_dir):
+        """Test _get_filepath integration with real temporary file."""
+        test_file = temp_dir / "integration_test.json"
+        test_file.write_text('{"test": "integration"}')
+
+        # Test with absolute path
+        result = _get_filepath(str(test_file))
+        assert result.exists()
+        assert result.name == "integration_test.json"
+
+    def test_get_filepath_strategies_isolated(self, temp_dir):
+        """Test _get_filepath strategies with controlled environment."""
+        test_file = temp_dir / "strategy_test.json"
+        test_file.write_text('{"test": "strategies"}')
+
+        # Test strategy 1 (absolute path)
+        result = _get_filepath(str(test_file))
+        assert result == test_file.resolve()
+
+        # Test strategy 2 (relative to CWD) with mocking instead of changing directory
+        original_path = Path
+
+        class MockPathForCWD(original_path):
+            def __new__(cls, *args, **kwargs):
+                instance = original_path.__new__(cls, *args, **kwargs)
+                return instance
+
+            def exists(self):
+                # Direct path doesn't exist, but CWD path does
+                if str(self) == "strategy_test.json":
+                    return False  # Direct doesn't exist
+                elif str(self).endswith(str(temp_dir / "strategy_test.json")):
+                    return True  # CWD path exists
+                return False
+
+            def resolve(self):
+                if str(self).endswith(str(temp_dir / "strategy_test.json")):
+                    return test_file.resolve()
+                return super().resolve()
+
+        with patch("eunomia_mcp.utils.Path", MockPathForCWD):
+            with patch("pathlib.Path.cwd") as mock_cwd:
+                mock_cwd.return_value = temp_dir
+
+                result = _get_filepath("strategy_test.json")
+                assert result.exists()
+                assert result.name == "strategy_test.json"

--- a/uv.lock
+++ b/uv.lock
@@ -343,7 +343,7 @@ wheels = [
 
 [[package]]
 name = "eunomia-ai"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "eunomia-core" },
@@ -390,7 +390,7 @@ docs = [
 
 [[package]]
 name = "eunomia-core"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "pkgs/core" }
 dependencies = [
     { name = "pydantic" },
@@ -401,7 +401,7 @@ requires-dist = [{ name = "pydantic", specifier = ">=2.10.6" }]
 
 [[package]]
 name = "eunomia-langchain"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "pkgs/extensions/langchain" }
 dependencies = [
     { name = "eunomia-sdk" },
@@ -418,7 +418,7 @@ requires-dist = [
 
 [[package]]
 name = "eunomia-mcp"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "pkgs/extensions/mcp" }
 dependencies = [
     { name = "eunomia-ai" },
@@ -439,7 +439,7 @@ requires-dist = [
 
 [[package]]
 name = "eunomia-sdk"
-version = "0.3.8"
+version = "0.3.9"
 source = { editable = "pkgs/sdks/python" }
 dependencies = [
     { name = "eunomia-core" },

--- a/uv.lock
+++ b/uv.lock
@@ -421,6 +421,7 @@ name = "eunomia-mcp"
 version = "0.3.8"
 source = { editable = "pkgs/extensions/mcp" }
 dependencies = [
+    { name = "eunomia-ai" },
     { name = "eunomia-sdk" },
     { name = "fastmcp" },
     { name = "pydantic" },
@@ -429,6 +430,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "eunomia-ai", editable = "." },
     { name = "eunomia-sdk", editable = "pkgs/sdks/python" },
     { name = "fastmcp", specifier = ">=2.10.4" },
     { name = "pydantic", specifier = ">=2.11.7" },


### PR DESCRIPTION
## Summary
MCP middleware now comes by default with an embedded Eunomia server, removing the need to spin up a separate server!

## Key changes
- Policy engine can be optionally set not to have a persistent storage
- MCP middleware can be set either to use an embedded Eunomia server or a remote Eunomia server via the client SDK
- When using an embedded server, users can load policies by directly passing a policy JSON to the middleware
- Updated documentation and unit tests accordingly
- CLI tool for custom policy generation accepts absolute paths

Ready for v0.3.9 🚀