### PR TITLE
fix: extended evaluator conditions and fixed a bug

### DIFF
--- a/pkgs/core/src/eunomia_core/enums/policy.py
+++ b/pkgs/core/src/eunomia_core/enums/policy.py
@@ -22,3 +22,5 @@ class ConditionOperator(str, Enum):
     # List operators
     IN = "in"
     NOT_IN = "not_in"
+    SUBSET = "subset"
+    NOT_SUBSET = "not_subset"

--- a/src/eunomia/engine/evaluator.py
+++ b/src/eunomia/engine/evaluator.py
@@ -60,24 +60,19 @@ def apply_operator(
         elif operator_type == enums.ConditionOperator.LESS_OR_EQUAL:
             return value <= target
     
+    # Subset operators: check if all items in value (list) are in target (list)
     elif isinstance(value, list) and isinstance(target, list):
-        if operator_type == enums.ConditionOperator.IN:
+        if operator_type == enums.ConditionOperator.SUBSET:
             return all(item in target for item in value)
-        elif operator_type == enums.ConditionOperator.NOT_IN:
+        elif operator_type == enums.ConditionOperator.NOT_SUBSET:
             return all(item not in target for item in value)
 
+    # IN/NOT_IN operators: target must be a collection (list)
     elif isinstance(target, list):
         if operator_type == enums.ConditionOperator.IN:
             return value in target
         elif operator_type == enums.ConditionOperator.NOT_IN:
             return value not in target
-    
-    elif isinstance(value, list):
-        if operator_type == enums.ConditionOperator.IN:
-            return target in value
-        elif operator_type == enums.ConditionOperator.NOT_IN:
-            return target not in value
-    
 
     return False
 

--- a/src/eunomia/engine/evaluator.py
+++ b/src/eunomia/engine/evaluator.py
@@ -59,12 +59,25 @@ def apply_operator(
             return value < target
         elif operator_type == enums.ConditionOperator.LESS_OR_EQUAL:
             return value <= target
+    
+    elif isinstance(value, list) and isinstance(target, list):
+        if operator_type == enums.ConditionOperator.IN:
+            return all(item in target for item in value)
+        elif operator_type == enums.ConditionOperator.NOT_IN:
+            return all(item not in target for item in value)
 
     elif isinstance(target, list):
         if operator_type == enums.ConditionOperator.IN:
             return value in target
         elif operator_type == enums.ConditionOperator.NOT_IN:
             return value not in target
+    
+    elif isinstance(value, list):
+        if operator_type == enums.ConditionOperator.IN:
+            return target in value
+        elif operator_type == enums.ConditionOperator.NOT_IN:
+            return target not in value
+    
 
     return False
 

--- a/tests/eunomia/engine/test_evaluator.py
+++ b/tests/eunomia/engine/test_evaluator.py
@@ -78,11 +78,23 @@ def test_apply_operator():
     assert apply_operator(enums.ConditionOperator.GREATER, 5, 3.5) is True
     assert apply_operator(enums.ConditionOperator.LESS, 3.5, 5) is True
 
+    # List membership operators - both value and target are lists
+    assert apply_operator(enums.ConditionOperator.IN, [1, 2], [1, 2, 3]) is True
+    assert apply_operator(enums.ConditionOperator.IN, [4, 5], [1, 2, 3]) is False
+    assert apply_operator(enums.ConditionOperator.NOT_IN, [4, 5], [1, 2, 3]) is True
+    assert apply_operator(enums.ConditionOperator.NOT_IN, [1, 2], [1, 2, 3]) is False
+
     # List membership operators - target is a list
     assert apply_operator(enums.ConditionOperator.IN, "admin", ["admin", "user"]) is True
     assert apply_operator(enums.ConditionOperator.IN, "guest", ["admin", "user"]) is False
     assert apply_operator(enums.ConditionOperator.NOT_IN, "guest", ["admin", "user"]) is True
     assert apply_operator(enums.ConditionOperator.NOT_IN, "admin", ["admin", "user"]) is False
+
+    # List membershipt operators  - value is a list
+    assert apply_operator(enums.ConditionOperator.IN, ["admin", "user"], "admin") is True
+    assert apply_operator(enums.ConditionOperator.IN, ["guest", "visitor"], "admin") is False
+    assert apply_operator(enums.ConditionOperator.NOT_IN, ["guest", "visitor"], "admin") is True
+    assert apply_operator(enums.ConditionOperator.NOT_IN, ["admin", "user"], "admin") is False
 
     # List with numbers - target is a list
     assert apply_operator(enums.ConditionOperator.IN, 2, [1, 2, 3]) is True

--- a/tests/eunomia/engine/test_evaluator.py
+++ b/tests/eunomia/engine/test_evaluator.py
@@ -78,30 +78,24 @@ def test_apply_operator():
     assert apply_operator(enums.ConditionOperator.GREATER, 5, 3.5) is True
     assert apply_operator(enums.ConditionOperator.LESS, 3.5, 5) is True
 
-    # List membership operators - both value and target are lists
-    assert apply_operator(enums.ConditionOperator.IN, [1, 2], [1, 2, 3]) is True
-    assert apply_operator(enums.ConditionOperator.IN, [1, 2], [2, 1]) is True
-    assert apply_operator(enums.ConditionOperator.IN, [4, 5], [1, 2, 3]) is False
-    assert apply_operator(enums.ConditionOperator.NOT_IN, [4, 5], [1, 2, 3]) is True
-    assert apply_operator(enums.ConditionOperator.NOT_IN, [1, 2], [1, 2, 3]) is False
-    assert apply_operator(enums.ConditionOperator.IN, ["a"], ["a", "b", "c"]) is True
-    assert apply_operator(enums.ConditionOperator.NOT_IN, ["d"], ["a", "b", "c"]) is True
-    assert apply_operator(enums.ConditionOperator.NOT_IN, ["a", "b"], ["a", "b", "c"]) is False
+    # Subset operators - both value and target are lists
+    assert apply_operator(enums.ConditionOperator.SUBSET, [1, 2], [1, 2, 3]) is True
+    assert apply_operator(enums.ConditionOperator.SUBSET, [1, 2], [2, 1]) is True
+    assert apply_operator(enums.ConditionOperator.SUBSET, [4, 5], [1, 2, 3]) is False
+    assert apply_operator(enums.ConditionOperator.NOT_SUBSET, [4, 5], [1, 2, 3]) is True
+    assert apply_operator(enums.ConditionOperator.NOT_SUBSET, [1, 2], [1, 2, 3]) is False
+    assert apply_operator(enums.ConditionOperator.SUBSET, ["a"], ["a", "b", "c"]) is True
+    assert apply_operator(enums.ConditionOperator.NOT_SUBSET, ["d"], ["a", "b", "c"]) is True
+    assert apply_operator(enums.ConditionOperator.NOT_SUBSET, ["a", "b"], ["a", "b", "c"]) is False
         
 
-    # List membership operators - target is a list
+    # List membership operators - target is a list (IN/NOT_IN with scalar value)
     assert apply_operator(enums.ConditionOperator.IN, "admin", ["admin", "user"]) is True
     assert apply_operator(enums.ConditionOperator.IN, "guest", ["admin", "user"]) is False
     assert apply_operator(enums.ConditionOperator.NOT_IN, "guest", ["admin", "user"]) is True
     assert apply_operator(enums.ConditionOperator.NOT_IN, "admin", ["admin", "user"]) is False
 
-    # List membershipt operators  - value is a list
-    assert apply_operator(enums.ConditionOperator.IN, ["admin", "user"], "admin") is True
-    assert apply_operator(enums.ConditionOperator.IN, ["guest", "visitor"], "admin") is False
-    assert apply_operator(enums.ConditionOperator.NOT_IN, ["guest", "visitor"], "admin") is True
-    assert apply_operator(enums.ConditionOperator.NOT_IN, ["admin", "user"], "admin") is False
-
-    # List with numbers - target is a list
+    # List with numbers - target is a list (IN/NOT_IN with scalar value)
     assert apply_operator(enums.ConditionOperator.IN, 2, [1, 2, 3]) is True
     assert apply_operator(enums.ConditionOperator.IN, 4, [1, 2, 3]) is False
     assert apply_operator(enums.ConditionOperator.NOT_IN, 4, [1, 2, 3]) is True
@@ -121,7 +115,14 @@ def test_apply_operator():
     assert apply_operator(enums.ConditionOperator.CONTAINS, 123, "test") is False
     assert apply_operator(enums.ConditionOperator.STARTS_WITH, 123, "test") is False
     assert apply_operator(enums.ConditionOperator.GREATER, "abc", "def") is False
+    
+    # IN operator requires target to be a list
     assert apply_operator(enums.ConditionOperator.IN, "not_a_list", "test") is False
+    assert apply_operator(enums.ConditionOperator.IN, ["admin", "user"], "admin") is False
+    
+    # SUBSET operator requires both value and target to be lists
+    assert apply_operator(enums.ConditionOperator.SUBSET, "admin", ["admin", "user"]) is False
+    assert apply_operator(enums.ConditionOperator.SUBSET, ["admin"], "not_a_list") is False
 
 
 def test_evaluate_condition():

--- a/tests/eunomia/engine/test_evaluator.py
+++ b/tests/eunomia/engine/test_evaluator.py
@@ -80,9 +80,14 @@ def test_apply_operator():
 
     # List membership operators - both value and target are lists
     assert apply_operator(enums.ConditionOperator.IN, [1, 2], [1, 2, 3]) is True
+    assert apply_operator(enums.ConditionOperator.IN, [1, 2], [2, 1]) is True
     assert apply_operator(enums.ConditionOperator.IN, [4, 5], [1, 2, 3]) is False
     assert apply_operator(enums.ConditionOperator.NOT_IN, [4, 5], [1, 2, 3]) is True
     assert apply_operator(enums.ConditionOperator.NOT_IN, [1, 2], [1, 2, 3]) is False
+    assert apply_operator(enums.ConditionOperator.IN, ["a"], ["a", "b", "c"]) is True
+    assert apply_operator(enums.ConditionOperator.NOT_IN, ["d"], ["a", "b", "c"]) is True
+    assert apply_operator(enums.ConditionOperator.NOT_IN, ["a", "b"], ["a", "b", "c"]) is False
+        
 
     # List membership operators - target is a list
     assert apply_operator(enums.ConditionOperator.IN, "admin", ["admin", "user"]) is True


### PR DESCRIPTION
Removing existing condition where value was a list in the previous pull request leads to breaking functionalities in applications if resource_condition values is a list.

Also added support for a condition where both target and value are lists. 