### PR TITLE
Adding SUPERSET and NOT_SUPERSET

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 dist/
 policies/
 node_modules/
+htmlcov/
+.coverage

--- a/pkgs/core/pyproject.toml
+++ b/pkgs/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eunomia-core"
-version = "0.3.10"
+version = "0.3.11"
 description = "Shared functionalities for Eunomia packages"
 authors = [
     { name="What About You team", email="info@whataboutyou.ai" }

--- a/pkgs/core/src/eunomia_core/enums/policy.py
+++ b/pkgs/core/src/eunomia_core/enums/policy.py
@@ -24,3 +24,5 @@ class ConditionOperator(str, Enum):
     NOT_IN = "not_in"
     SUBSET = "subset"
     NOT_SUBSET = "not_subset"
+    SUPERSET = "superset"
+    NOT_SUPERSET = "not_superset"

--- a/pkgs/sdks/python/pyproject.toml
+++ b/pkgs/sdks/python/pyproject.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "eunomia-core>=0.3.10",
+    "eunomia-core>=0.3.11",
     "httpx>=0.28.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eunomia-ai"
-version = "0.3.10"
+version = "0.3.11"
 description = "Authorization layer for AI Agents"
 authors = [
     { name="What About You team", email="info@whataboutyou.ai" }
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "eunomia-core>=0.3.10",
+    "eunomia-core>=0.3.11",
     "fastapi[standard]>=0.115.9",
     "httpx>=0.28.1",
     "pydantic-settings>=2.8.1",

--- a/src/eunomia/engine/evaluator.py
+++ b/src/eunomia/engine/evaluator.py
@@ -1,7 +1,8 @@
 from typing import Any
-
+from logging import getLogger
 from eunomia_core import enums, schemas
 
+LOGGER = getLogger("eunomia_engine")
 
 def get_attribute_value(obj: Any, path: str) -> Any:
     """Extract a value from an object using dot notation path."""
@@ -27,6 +28,14 @@ def get_attribute_value(obj: Any, path: str) -> Any:
 
     return current
 
+def _to_set(arg: Any) -> set:
+    """Helper function for converting diverse data types to sets"""
+    if isinstance(arg, list):
+        return set(tuple(arg))
+    if isinstance(arg, str):
+        return {arg}
+    return set(arg)
+
 
 def apply_operator(
     operator_type: enums.ConditionOperator, value: Any, target: Any
@@ -34,47 +43,53 @@ def apply_operator(
     """Apply the specified operator with the value against the target."""
     if value is None or target is None:
         return False
+    try:
 
-    if operator_type == enums.ConditionOperator.EQUALS:
-        return value == target
-    elif operator_type == enums.ConditionOperator.NOT_EQUALS:
-        return value != target
+        match operator_type:
+            # Equivalency checks
+            case enums.ConditionOperator.EQUALS:
+                return value == target
+            case enums.ConditionOperator.NOT_EQUALS:
+                return value != target
+            # String checks
+            case enums.ConditionOperator.STARTS_WITH:
+                return target.startswith(value)
+            case enums.ConditionOperator.ENDS_WITH:
+                return target.endswith(value)
+            # Math checks
+            case enums.ConditionOperator.GREATER:
+                return value > target
+            case enums.ConditionOperator.GREATER_OR_EQUAL:
+                return value >= target
+            case enums.ConditionOperator.LESS:
+                return value < target
+            case enums.ConditionOperator.LESS_OR_EQUAL:
+                return value <= target
 
-    if isinstance(value, str) and isinstance(target, str):
-        if operator_type == enums.ConditionOperator.CONTAINS:
-            return value in target
-        elif operator_type == enums.ConditionOperator.NOT_CONTAINS:
-            return value not in target
-        elif operator_type == enums.ConditionOperator.STARTS_WITH:
-            return target.startswith(value)
-        elif operator_type == enums.ConditionOperator.ENDS_WITH:
-            return target.endswith(value)
+            # Contains and IN checks
+            case enums.ConditionOperator.CONTAINS | enums.ConditionOperator.IN:
+                return value in target
+            case enums.ConditionOperator.NOT_CONTAINS | enums.ConditionOperator.NOT_IN:
+                return value not in target
 
-    elif isinstance(value, (int, float)) and isinstance(target, (int, float)):
-        if operator_type == enums.ConditionOperator.GREATER:
-            return value > target
-        elif operator_type == enums.ConditionOperator.GREATER_OR_EQUAL:
-            return value >= target
-        elif operator_type == enums.ConditionOperator.LESS:
-            return value < target
-        elif operator_type == enums.ConditionOperator.LESS_OR_EQUAL:
-            return value <= target
-    
-    # Subset operators: check if all items in value (list) are in target (list)
-    elif isinstance(value, list) and isinstance(target, list):
-        if operator_type == enums.ConditionOperator.SUBSET:
-            return all(item in target for item in value)
-        elif operator_type == enums.ConditionOperator.NOT_SUBSET:
-            return all(item not in target for item in value)
+            # Subset operators: check if all items in value (set) are in target (set)
+            case enums.ConditionOperator.SUBSET:
+                return all(item in target for item in value)
+            case enums.ConditionOperator.NOT_SUBSET:
+                return all(item not in target for item in value)
+            # Superset operators: check to see if the target resource is a superset of the value(s)
+            case enums.ConditionOperator.SUPERSET:
+                return _to_set(value).issuperset(_to_set(target))
+            case enums.ConditionOperator.NOT_SUPERSET:
+                return not _to_set(value).issuperset(_to_set(target))
 
-    # IN/NOT_IN operators: target must be a collection (list)
-    elif isinstance(target, list):
-        if operator_type == enums.ConditionOperator.IN:
-            return value in target
-        elif operator_type == enums.ConditionOperator.NOT_IN:
-            return value not in target
+            # Default case
+            case _:
+                return False
 
-    return False
+    except TypeError as err:
+        LOGGER.warning(f"Unexpected target/value variable types, {err}")
+        return False
 
 
 def evaluate_condition(condition: schemas.Condition, obj: Any) -> bool:

--- a/tests/eunomia/engine/test_evaluator.py
+++ b/tests/eunomia/engine/test_evaluator.py
@@ -124,6 +124,21 @@ def test_apply_operator():
     assert apply_operator(enums.ConditionOperator.SUBSET, "admin", ["admin", "user"]) is False
     assert apply_operator(enums.ConditionOperator.SUBSET, ["admin"], "not_a_list") is False
 
+    # SUPERSET operator requires target to be a superset of the policy value
+    assert apply_operator(enums.ConditionOperator.SUPERSET, "admin", ["admin", "user"]) is False
+    assert apply_operator(enums.ConditionOperator.SUPERSET, ["admin", "user"], "admin") is True
+    assert apply_operator(enums.ConditionOperator.SUPERSET, "admin", "user") is False
+    assert apply_operator(enums.ConditionOperator.SUPERSET, ["admin", "user"], ["admin"]) is True
+    assert apply_operator(enums.ConditionOperator.SUPERSET, 1, 1) is False  # Raises TypeError
+
+    assert apply_operator(enums.ConditionOperator.NOT_SUPERSET, ["admin", "user"], "power_user") is True
+    assert apply_operator(enums.ConditionOperator.NOT_SUPERSET, ["admin", "user"], "user") is False
+
+    # Invalid / Empty operator returns False
+    assert apply_operator(None, "admin", "user") is False
+
+    # Assert that TypeErrors are caught and returned as False
+    assert apply_operator(enums.ConditionOperator.IN, [1, 2, 3], 4) is False
 
 def test_evaluate_condition():
     condition = schemas.Condition(


### PR DESCRIPTION
Suggested updates for a possible version `0.3.11` of `eunomia-core` and `eunomia-ai` which also includes updates from JoonasBot to the subset and not_subset evaluators. A quick overview of the changes:

- Proposed updates to `evaluators.py` and alter conditionals to python3.10+ match/case statement
    - Alters logic to focus on the operator argument instead of the variable types
    - Any invalid typed variables are caught by `TypeError` and default to `False`
    - Any undefined operators default to `False`
- Adding `superset` and `not_superset` to provide a check and confirm if the `target` is a superset of the defined policy `values`
- Added additional tests to validate match/case changes as well as `superset` and `not_superset`